### PR TITLE
feat: Implement IMX quantization method and add quantize.yaml file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN apt-get update && apt-get install -y wget bzip2 curl make unzip git && \
     rm Miniconda3-latest-Linux-x86_64.sh && \
     /opt/conda/bin/conda init bash
 
+# Install Java (needed for IMX export)
+RUN apt-get update && apt-get install -y openjdk-21-jre && apt-get clean
+
 # Set working directory
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   capstone:
-    image: celt313/automl_capstone:v0.0.1
+    image: celt313/automl_capstone:v0.0.2
+    shm_size: "4gb"
     container_name: automl_capstone
     working_dir: /app
     entrypoint: bash
@@ -19,7 +20,7 @@ services:
               capabilities: [gpu]
 
   generate_box:
-    image: celt313/automl_capstone:v0.0.1
+    image: celt313/automl_capstone:v0.0.2
     profiles: ["optional"]
     entrypoint: bash
     command: -c "source activate capstone_env && python src/generate_boxed_images.py"
@@ -27,7 +28,7 @@ services:
       - .:/app
 
   human_intervention:
-    image: celt313/automl_capstone:v0.0.1
+    image: celt313/automl_capstone:v0.0.2
     profiles: ["optional"]
     entrypoint: bash
     command: -c "source activate capstone_env && python src/pipeline/human_intervention.py"
@@ -35,7 +36,7 @@ services:
       - .:/app
 
   test:
-    image: celt313/automl_capstone:v0.0.1
+    image: celt313/automl_capstone:v0.0.2
     profiles: ["optional"]
     entrypoint: bash
     command: -c "source activate capstone_env && pytest tests/"

--- a/environment.yml
+++ b/environment.yml
@@ -1,3 +1,12 @@
+# This environment installs CPU-only PyTorch by default (pytorch=2.6.0 via conda-forge).
+# If you want to run the pipeline with GPU support, you need to install the GPU-compatible version of PyTorch manually.
+#
+#   conda activate capstone_env
+#   pip uninstall torch torchvision
+#   pip install torch==2.5.1+cu124 torchvision==0.20.1+cu124 --index-url https://download.pytorch.org/whl/cu124
+#
+# [NOTE] Compatibility issues have been reported with PyTorch 2.6.0 and Ultralytics
+# Make sure the CUDA version shown by `nvcc -V` matches the "+cuXXX" suffix of your torch install (e.g., cu124 = CUDA 12.4).
 name: capstone_env
 channels:
   - conda-forge

--- a/human_review_env.yml
+++ b/human_review_env.yml
@@ -1,0 +1,12 @@
+# If you only want to run human intervention, you only need to install the dependencies in this file.
+name: human_review_env
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - pip
+  - pip:
+      - dotenv==0.9.9
+      - python-dotenv==1.1.0
+      - label-studio==1.17.0
+      - label-studio-sdk==1.0.11

--- a/src/main.py
+++ b/src/main.py
@@ -179,14 +179,10 @@ def main():
     # 8. Model quantization
     # Replace with distilled_model, this is for testing using the full model
     distilled_model_path = model_dir / "model" / "nano_trained_model.pt"
-    quantize_yaml_path = SCRIPT_DIR / "quantize.yaml"
+    quantize_config_path = SCRIPT_DIR / "quantize_config.json"
     quantized_model_path = quantize_model(
-        model_path=distilled_model_path,
-        config={
-            'method': config.get('quantization_method'),
-            'output_dir': str(quantized_output_dir)
-        },
-        quantize_yaml=str(quantize_yaml_path)
+        model_path=str(distilled_model_path),
+        quantize_config_path=str(quantize_config_path)
     )
 
     print("-----------------------------------------------\n")

--- a/src/main.py
+++ b/src/main.py
@@ -162,25 +162,28 @@ def main():
     print(" --- Step 7: Model optimization --- ")
 
     # 7. Model optimization
-    distilled_model_path, distill_config_path = distill_model(
-        model_path=model_path,
-        distillation_images=distillation_dir,
-        config=config,
-        output_dir=distilled_output_dir,
-        config_registry_path=config_dir
-    )
+    # Commented out for now to ensure the pipeline runs without distillation
+    # distilled_model_path, distill_config_path = distill_model(
+    #     model_path=model_path,
+    #     distillation_images=distillation_dir,
+    #     config=config,
+    #     output_dir=distilled_output_dir,
+    #     config_registry_path=config_dir
+    # )
 
     print("-----------------------------------------------\n")
     print(" --- Step 8: Model quantization --- ")
     # 8. Model quantization
     # Replace with distilled_model, this is for testing using the full model
     distilled_model_path = model_dir / "model" / "nano_trained_model.pt"
-    quantized_model = quantize_model(
+    quantize_yaml_path = SCRIPT_DIR / "quantize.yaml"
+    quantized_model_path = quantize_model(
         model_path=distilled_model_path,
         config={
             'method': config.get('quantization_method'),
             'output_dir': str(quantized_output_dir)
-        }
+        },
+        quantize_yaml=str(quantize_yaml_path)
     )
 
     print("-----------------------------------------------\n")

--- a/src/pipeline/quantization.py
+++ b/src/pipeline/quantization.py
@@ -8,7 +8,10 @@ import shutil
 import platform
 from ultralytics import YOLO
 import subprocess
+from datetime import datetime
+from pathlib import Path
 from onnxruntime.quantization import quantize_dynamic, QuantType
+from utils import prepare_quantization_data, load_config
 
 
 def imx_quantization(model, output_path, quantize_yaml):
@@ -32,13 +35,30 @@ def imx_quantization(model, output_path, quantize_yaml):
     # Apply IMX quantization
     print(f"Applying IMX quantization using device {device}...")
 
-    # Export the model to IMX format
-    export_result = model.export(format="imx", data=quantize_yaml, device=device)
-    exported_path = export_result[0]
+    try:
+        # Export the model to IMX format (no fraction parameter)
+        export_result = model.export(format="imx", data=quantize_yaml, device=device)
+        if isinstance(export_result, (list, tuple)) and len(export_result) > 0:
+            exported_path = export_result[0]
+        else:
+            exported_path = str(export_result)
 
-    shutil.move(exported_path, output_path)
-    print(f"IMX quantized model saved to {output_path}")
-    return output_path
+        if os.path.exists(exported_path):
+            if os.path.exists(output_path):
+                if os.path.isdir(output_path):
+                    shutil.rmtree(output_path)
+                else:
+                    os.remove(output_path)
+            shutil.move(exported_path, output_path)
+            print(f"[INFO] IMX quantized model saved to {output_path}")
+            return output_path
+        else:
+            print(f"[ERROR] Export result not found: {exported_path}")
+            return None
+
+    except Exception as e:
+        print(f"[ERROR] IMX quantization failed: {str(e)}")
+        return None
 
 
 def fp16_quantization(model, output_path):
@@ -54,13 +74,14 @@ def fp16_quantization(model, output_path):
     """
     # Apply FP16 quantization
     print("Applying FP16 quantization...")
-    model.model = model.model.half()
-
-    # Save the quantized model
-    model.save(output_path)
-
-    print(f"FP16 quantized model saved to {output_path}")
-    return output_path
+    try:
+        model.model = model.model.half()
+        model.save(output_path)
+        print(f"[INFO] FP16 quantized model saved to {output_path}")
+        return output_path
+    except Exception as e:
+        print(f"[ERROR] FP16 quantization failed: {str(e)}")
+        return None
 
 
 def onnx_quantization(model, output_path, preprocessed_path):
@@ -77,46 +98,52 @@ def onnx_quantization(model, output_path, preprocessed_path):
     """
     # Export the model to ONNX format
     print("Exporting model to ONNX format...")
-    onnx_path = model.export(format='onnx')
+    try:
+        onnx_path = model.export(format='onnx')
 
-    # Preprocess the ONNX model
-    print("Preprocessing ONNX model...")
-    subprocess.run([
-        "python", "-m", "onnxruntime.quantization.preprocess",
-        "--input", onnx_path,
-        "--output", preprocessed_path
-    ], check=True)
+        # Preprocess the ONNX model
+        print("Preprocessing ONNX model...")
+        subprocess.run([
+            "python", "-m", "onnxruntime.quantization.preprocess",
+            "--input", onnx_path,
+            "--output", preprocessed_path
+        ], check=True)
 
-    # Apply dynamic quantization
-    print("Applying dynamic quantization...")
-    quantize_dynamic(
-        preprocessed_path,
-        output_path,
-        weight_type=QuantType.QUInt8
-    )
+        # Apply dynamic quantization
+        print("Applying dynamic quantization...")
+        quantize_dynamic(
+            preprocessed_path,
+            output_path,
+            weight_type=QuantType.QUInt8
+        )
 
-    # Clean up the preprocessed model
-    if os.path.exists(onnx_path) and onnx_path != output_path:
-        os.remove(onnx_path)
+        # Clean up the preprocessed model
+        if os.path.exists(onnx_path) and onnx_path != output_path:
+            os.remove(onnx_path)
+        print(f"ONNX quantized model saved to {output_path}")
+        return output_path
 
-    print(f"ONNX quantized model saved to {output_path}")
-    return output_path
+    except Exception as e:
+        print(f"[ERROR] ONNX quantization failed: {str(e)}")
+        return None
 
 
-def quantize_model(model_path: str, config: dict, quantize_yaml: str = None) -> str:
+def quantize_model(model_path: str, quantize_config_path: str) -> str:
     """
     Apply quantization to the model to reduce size and improve inference speed.
 
     Args:
         model_path (str): Path to the model to quantize
-        config (dict): Quantization configuration parameters
-        quantize_yaml (str): Path to YAML file for IMX export
+        quantize_config_path (str): Path to quantization configuration file
 
     Returns:
         str: Path to the quantized model
     """
-    output_dir = config.get('output_dir', 'quantized_models')
-    quant_method = config.get('method')
+    print(f"[INFO] Loading quantization config from {quantize_config_path}")
+    quantize_config = load_config(quantize_config_path)
+
+    output_dir = quantize_config.get('output_dir', 'quantized_models')
+    quant_method = quantize_config.get('quantization_method', 'IMX')
     os.makedirs(output_dir, exist_ok=True)
 
     # Load the model
@@ -126,22 +153,36 @@ def quantize_model(model_path: str, config: dict, quantize_yaml: str = None) -> 
     model_name = os.path.basename(str(model_path))
     base_name = os.path.splitext(model_name)[0]
 
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H_%M_%S")
+
+    quantize_yaml = None
+
+    # Prepare calibration data if using IMX quantization
+    if quant_method == "IMX":
+        print("[INFO] Preparing calibration data for IMX quantization...")
+
+        labeled_images_dir = Path(quantize_config["labeled_images_path"])
+        calibration_samples = quantize_config.get("calibration_samples", 200)
+
+        prepare_quantization_data(quantize_config, labeled_images_dir, calibration_samples)
+
+        quantize_yaml = quantize_config.get("quantize_yaml_path", "src/quantize.yaml")
+
+        if not os.path.exists(quantize_yaml):
+            raise ValueError(f"The quantize_yaml file does not exist at: {quantize_yaml}")
+
     # Quantize the model based on the configured method
     if quant_method == "ONNX":
-        preprocessed_path = os.path.join(output_dir, f"{base_name}_preprocessed.onnx")
-        output_path = os.path.join(output_dir, f"{base_name}_onnx_quantized.onnx")
+        preprocessed_path = os.path.join(output_dir, f"{timestamp}_{base_name}_preprocessed.onnx")
+        output_path = os.path.join(output_dir, f"{timestamp}_{base_name}_onnx_quantized_model.onnx")
         return onnx_quantization(model, output_path, preprocessed_path)
 
     elif quant_method == "FP16":
-        output_path = os.path.join(output_dir, f"{base_name}_fp16.pt")
+        output_path = os.path.join(output_dir, f"{timestamp}_{base_name}_fp16_quantized_model.pt")
         return fp16_quantization(model, output_path)
 
     elif quant_method == "IMX":
-        if not quantize_yaml:
-            raise ValueError("IMX quantization requires a quantize_yaml path.")
-        if not os.path.exists(quantize_yaml):
-            raise ValueError(f"The quantize_yaml file does not exist at the specified path: {quantize_yaml}")
-        output_path = os.path.join(output_dir, f"{base_name}_imx_quantized")
+        output_path = os.path.join(output_dir, f"{timestamp}_{base_name}_imx_quantized_model")
         return imx_quantization(model, output_path, quantize_yaml)
 
     else:

--- a/src/pipeline/quantization.py
+++ b/src/pipeline/quantization.py
@@ -139,6 +139,8 @@ def quantize_model(model_path: str, config: dict, quantize_yaml: str = None) -> 
     elif quant_method == "IMX":
         if not quantize_yaml:
             raise ValueError("IMX quantization requires a quantize_yaml path.")
+        if not os.path.exists(quantize_yaml):
+            raise ValueError(f"The quantize_yaml file does not exist at the specified path: {quantize_yaml}")
         output_path = os.path.join(output_dir, f"{base_name}_imx_quantized.pt")
         return imx_quantization(model, output_path, quantize_yaml)
 

--- a/src/pipeline/quantization.py
+++ b/src/pipeline/quantization.py
@@ -18,6 +18,8 @@ def imx_quantization(model, output_path, quantize_yaml):
     """
     Apply IMX post training quantization to the model.
 
+    Note - 300+ images recommended for IMX INT8 calibration.
+
     Args:
         model: YOLO model to quantize
         output_path: Path to save the quantized model

--- a/src/pipeline/quantization.py
+++ b/src/pipeline/quantization.py
@@ -141,7 +141,7 @@ def quantize_model(model_path: str, config: dict, quantize_yaml: str = None) -> 
             raise ValueError("IMX quantization requires a quantize_yaml path.")
         if not os.path.exists(quantize_yaml):
             raise ValueError(f"The quantize_yaml file does not exist at the specified path: {quantize_yaml}")
-        output_path = os.path.join(output_dir, f"{base_name}_imx_quantized.pt")
+        output_path = os.path.join(output_dir, f"{base_name}_imx_quantized")
         return imx_quantization(model, output_path, quantize_yaml)
 
     else:

--- a/src/pipeline/quantization.py
+++ b/src/pipeline/quantization.py
@@ -21,7 +21,7 @@ def imx_quantization(model, output_path, quantize_yaml):
         quantize_yaml: Path to quantize.yaml with nc and class names
 
     Returns:
-        str: Path to the quantized model
+        str or None: Path to the quantized model, or None if on non-Linux platforms.
     """
     # Check if the platform is Linux
     if platform.system().lower() != "linux":

--- a/src/pipeline_config.json
+++ b/src/pipeline_config.json
@@ -56,6 +56,5 @@
   "true_negative_images_path": "mock_io/data/augmented/no_prediction_images",
   "training_output_path": "mock_io/data/training",
   "train_val_split": [0.7, 0.2, 0.1],
-  "data_yaml_path": "mock_io/data/training/data.yaml",
-  "quantization_method": "ONNX"
+  "data_yaml_path": "mock_io/data/training/data.yaml"
 }

--- a/src/quantize.yaml
+++ b/src/quantize.yaml
@@ -1,2 +1,0 @@
-nc: 5
-names: ['FireBSI', 'LightningBSI', 'PersonBSI', 'SmokeBSI', 'VehicleBSI']

--- a/src/quantize.yaml
+++ b/src/quantize.yaml
@@ -1,0 +1,2 @@
+nc: 5
+names: ['FireBSI', 'LightningBSI', 'PersonBSI', 'SmokeBSI', 'VehicleBSI']

--- a/src/quantize_config.json
+++ b/src/quantize_config.json
@@ -1,0 +1,10 @@
+{
+  "labeled_json_path": "mock_io/data/labeled",
+  "labeled_images_path": "mock_io/data/raw/images",
+  "quantization_data_path": "data/quantization",
+  "quantize_yaml_path": "src/quantize.yaml",
+
+  "quantization_method": "IMX",
+  "calibration_samples": 20,
+  "output_dir": "mock_io/model_registry/quantized"
+}

--- a/src/utils.py
+++ b/src/utils.py
@@ -252,3 +252,192 @@ def prepare_training_data(config: dict):
 
     # Create data.yaml file
     create_data_yaml(out_dir)
+
+
+def prepare_quantization_data(config: dict, image_dir: Path, calibration_samples: int = 200):
+    """
+    Prepare a calibration dataset for IMX quantization by sampling from incoming data.
+
+    Args:
+        config (dict): Dictionary containing required paths.
+                       Expected keys:
+                       - "labeled_json_path" (original labeled data)
+                       - "quantization_data_path" (where to save calibration data)
+        image_dir (Path): Directory containing the labeled images to sample from.
+        calibration_samples (int): Number of images to use for calibration (default: 200)
+    """
+    quant_dir = Path(config.get("quantization_data_path", "data/quantization"))
+
+    # If calibration data already exists, use it
+    if (quant_dir / "images" / "train").exists() and (quant_dir / "images" / "val").exists():
+        print(f"[INFO] Using existing calibration data at '{quant_dir}'")
+        print("[INFO] To recreate calibration data, delete the quantization directory")
+        create_quantize_yaml(quant_dir)
+        return
+
+    print("[INFO] Creating new calibration dataset...")
+
+    labeled_json_dir = Path(config.get("labeled_json_path", "mock_io/data/labeled"))
+
+    if not labeled_json_dir.exists():
+        raise FileNotFoundError(f"Labeled JSON directory not found at {labeled_json_dir}")
+    if not image_dir.exists():
+        raise FileNotFoundError(f"Image directory not found at {image_dir}")
+
+    # Convert classes to int in a dictionary (same as training)
+    class_map = {
+        "FireBSI": 0,
+        "LightningBSI": 1,
+        "PersonBSI": 2,
+        "SmokeBSI": 3,
+        "VehicleBSI": 4
+    }
+
+    all_image_label_pairs = []
+
+    # Process JSON labels to YOLO format using the provided image_dir
+    json_files = list(labeled_json_dir.glob("*.json"))
+    image_files = [f for f in image_dir.glob("*") if f.suffix.lower() in [".jpg", ".jpeg", ".png"]]
+    image_lookup = {f.stem.lower(): f for f in image_files}
+
+    # Match JSON files to images
+    matched_pairs = [
+        (json_file, image_lookup[json_file.stem.lower()])
+        for json_file in json_files
+        if json_file.stem.lower() in image_lookup
+    ]
+
+    print(f"[INFO] Matched {len(matched_pairs)} JSON-image pairs")
+
+    for json_file, image_file in matched_pairs:
+        with open(json_file) as f:
+            data = json.load(f)
+
+        yolo_lines = []
+        im = Image.open(image_file)
+        w, h = im.size
+
+        # Only process images that have predictions
+        predictions = data.get("predictions", [])
+        if not predictions:
+            continue
+
+        for ann in predictions:
+            cls = ann["class"]
+            if cls not in class_map:
+                print(f"Unknown class '{cls}' in {json_file.name}. Skipping annotation.")
+                continue
+            class_id = class_map[cls]
+
+            # Convert [xmin, ymin, xmax, ymax] to YOLO format: https://medium.com/@telega.slawomir.ai/json-to-yolo-dataset-converter-9e9e643a31a7
+            x_min, y_min, x_max, y_max = ann["bbox"]
+            box_w = x_max - x_min
+            box_h = y_max - y_min
+            x_center = (x_min + box_w / 2) / w
+            y_center = (y_min + box_h / 2) / h
+            norm_w = box_w / w
+            norm_h = box_h / h
+
+            yolo_lines.append(f"{class_id} {x_center:.6f} {y_center:.6f} {norm_w:.6f} {norm_h:.6f}")
+
+        if yolo_lines:
+            all_image_label_pairs.append((image_file, yolo_lines))
+
+    print(f"[INFO] Found {len(all_image_label_pairs)} images with valid annotations for calibration")
+
+    # Stratified sampling to ensure class representation
+    class_images = {i: [] for i in range(5)}
+    for img_path, labels in all_image_label_pairs:
+        classes_in_image = set()
+        for label in labels:
+            class_id = int(label.split()[0])
+            classes_in_image.add(class_id)
+        for class_id in classes_in_image:
+            class_images[class_id].append((img_path, labels))
+
+    for class_id in range(5):
+        print(f"[INFO] Class {class_id}: {len(class_images[class_id])} images available")
+
+    # Sample from each class proportionally
+    selected_pairs = []
+    samples_per_class = calibration_samples // 5
+
+    for class_id in range(5):
+        class_samples = class_images[class_id]
+        if class_samples:
+            n_samples = min(samples_per_class, len(class_samples))
+            if n_samples > 0:
+                sampled = random.sample(class_samples, n_samples)
+                selected_pairs.extend(sampled)
+                print(f"[INFO] Sampled {len(sampled)} images for class {class_id}")
+            else:
+                print(f"[WARNING] No samples available for class {class_id}")
+
+    # Remove duplicates
+    seen_images = set()
+    unique_pairs = []
+    for img_path, labels in selected_pairs:
+        img_name = img_path.name
+        if img_name not in seen_images:
+            seen_images.add(img_name)
+            unique_pairs.append((img_path, labels))
+
+    selected_pairs = unique_pairs[:calibration_samples]
+    random.shuffle(selected_pairs)
+
+    print(f"[INFO] Selected {len(selected_pairs)} unique images for IMX calibration")
+
+    # Create IMX quantization dataset structure
+    calib_train_ratio = 0.8
+    n_train = int(len(selected_pairs) * calib_train_ratio)
+
+    train_pairs = selected_pairs[:n_train]
+    val_pairs = selected_pairs[n_train:]
+
+    # Save calibration dataset
+    for split_name, split_data in zip(["train", "val"], [train_pairs, val_pairs]):
+        for img_path, labels in split_data:
+            dest_img = quant_dir / "images" / split_name / img_path.name
+            dest_lbl = quant_dir / "labels" / split_name / (img_path.stem + ".txt")
+            dest_img.parent.mkdir(parents=True, exist_ok=True)
+            dest_lbl.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(img_path, dest_img)
+            with open(dest_lbl, "w") as f:
+                f.write("\n".join(labels))
+
+    print(f"[INFO] IMX calibration data prepared at '{quant_dir}'")
+    print(f"[INFO] Calibration Train: {len(train_pairs)}, Val: {len(val_pairs)}")
+
+    # Create quantize.yaml file for IMX
+    create_quantize_yaml(quant_dir)
+
+
+def create_quantize_yaml(output_dir: str, yaml_path: str = None):
+    """
+    Create a quantize.yaml file for IMX quantization with absolute paths.
+
+    Args:
+        output_dir (str): Directory containing the calibration images and labels.
+        yaml_path (str, optional): Output path for the YAML file.
+                                  Defaults to "src/quantize.yaml".
+    """
+    if yaml_path is None:
+        yaml_path = "src/quantize.yaml"
+
+    # Resolve absolute paths (no test path for quantization)
+    train_path = os.path.abspath(os.path.join(output_dir, "images", "train"))
+    val_path = os.path.abspath(os.path.join(output_dir, "images", "val"))
+
+    # YAML content
+    quantize_yaml = {
+        "train": train_path,
+        "val": val_path,
+        "nc": 5,
+        "names": ["FireBSI", "LightningBSI", "PersonBSI", "SmokeBSI", "VehicleBSI"]
+    }
+
+    # Write YAML file
+    with open(yaml_path, "w") as f:
+        yaml.dump(quantize_yaml, f, sort_keys=False, default_flow_style=None)
+
+    print(f"[INFO] quantize.yaml saved to: {yaml_path}")


### PR DESCRIPTION
This PR adds support for IMX post-training quantization based on [this doc](https://docs.ultralytics.com/integrations/sony-imx500/) from Ultralytics.

### Changes

`imx_quantization(model, output_path, quantize_yaml)`
- Exports the model in IMX format using `model.export()`, moves it to the desired path, and uses GPU if available to speed things up.

`quantize_model(...)`
- Now supports "IMX" as one of the three quantization methods.

### Note

Unfortuantely, according to [Sony’s IMX500 converter documentation](https://developer.aitrios.sony-semicon.com/en/raspberrypi-ai-camera/documentation/imx500-converter?version=3.16.1&progLang=), IMX export is currently only supported on Linux.  Let's test this once our Docker container is ready.

