### PR TITLE
feat: Add transformation of Label Studio exports to labeled format

### DIFF
--- a/src/pipeline/human_intervention.py
+++ b/src/pipeline/human_intervention.py
@@ -21,11 +21,25 @@ reviewed_dir = mismatch_dir / "reviewed_results"
 image_dir = Path("mock_io/data/raw/images")
 output_dir = Path("mock_io/data/ls_tasks")
 labeled_dir = Path("mock_io/data/labeled")
-mismatch_dir.mkdir(exist_ok=True)
-mismatch_pending_dir.mkdir(exist_ok=True)
-reviewed_dir.mkdir(exist_ok=True)
-output_dir.mkdir(exist_ok=True)
-labeled_dir.mkdir(exist_ok=True)
+
+
+def _ensure_directories():
+    """
+    Create necessary directories for the human intervention workflow.
+
+    This function creates all required directories if they don't exist.
+    Called only when the script is actually running.
+    """
+    directories = [
+        mismatch_dir,
+        mismatch_pending_dir,
+        reviewed_dir,
+        output_dir,
+        labeled_dir
+    ]
+
+    for directory in directories:
+        directory.mkdir(parents=True, exist_ok=True)
 
 
 def _find_image_path(stem: str, image_dir: Path) -> Path:
@@ -856,6 +870,9 @@ def run_human_review(project_name: str = "AutoML-Human-Intervention",
     Returns:
         dict: Dictionary containing the results of the human review process.
     """
+    # Ensure directories exist
+    _ensure_directories()
+
     # Initialize JSON files in the pending folder
     _initialize_json_files(mismatch_pending_dir)
 

--- a/src/pipeline/human_intervention.py
+++ b/src/pipeline/human_intervention.py
@@ -17,15 +17,15 @@ from dotenv import load_dotenv
 
 mismatch_dir = Path("mock_io/data/mismatched")
 mismatch_pending_dir = mismatch_dir / "pending"
-# mismatch_imported_dir = mismatch_dir / "imported"
 reviewed_dir = mismatch_dir / "reviewed_results"
 image_dir = Path("mock_io/data/raw/images")
 output_dir = Path("mock_io/data/ls_tasks")
+labeled_dir = Path("mock_io/data/labeled")
 mismatch_dir.mkdir(exist_ok=True)
 mismatch_pending_dir.mkdir(exist_ok=True)
-# mismatch_imported_dir.mkdir(exist_ok=True)
 reviewed_dir.mkdir(exist_ok=True)
 output_dir.mkdir(exist_ok=True)
+labeled_dir.mkdir(exist_ok=True)
 
 
 def _find_image_path(stem: str, image_dir: Path) -> Path:
@@ -122,6 +122,31 @@ def _convert_bbox_to_percent(bbox, img_width, img_height):
     }
 
 
+def _convert_bbox_from_percent(bbox_dict, img_width, img_height):
+    """
+    Converts bounding box coordinates from percentage back to pixel format.
+
+    Args:
+        bbox_dict (dict): Bbox with x, y, width, height in percentages
+        img_width (int): Width of the image in pixels
+        img_height (int): Height of the image in pixels
+
+    Returns:
+        list: Bounding box in [x1, y1, x2, y2] pixel format
+    """
+    x_percent = bbox_dict["x"]
+    y_percent = bbox_dict["y"]
+    width_percent = bbox_dict["width"]
+    height_percent = bbox_dict["height"]
+
+    x1 = (x_percent / 100) * img_width
+    y1 = (y_percent / 100) * img_height
+    x2 = x1 + (width_percent / 100) * img_width
+    y2 = y1 + (height_percent / 100) * img_height
+
+    return [x1, y1, x2, y2]
+
+
 def _generate_ls_tasks(json_dir: Path, image_dir: Path, output_dir: Path):
     """
     Converts mismatched YOLOv8 prediction JSON files into a single
@@ -170,7 +195,11 @@ def _generate_ls_tasks(json_dir: Path, image_dir: Path, output_dir: Path):
                     "from_name": "bbox",
                     "to_name": "image",
                     "type": "rectanglelabels",
-                    "value": box
+                    "value": box,
+                    "meta": {
+                        "confidence": item.get("confidence", 0.0),
+                        "confidence_flag": item.get("confidence_flag", "N.A.")
+                    }
                 })
 
             # Encode image to base64
@@ -601,11 +630,126 @@ def export_versioned_results(project_id: str, output_dir: Path, version: str = N
         print("[✓] Exported results:")
         print(f"    - {len(results)} tasks ({labeled_results_count} labeled): {results_path}")
 
+        # Transform results to labeled directory
+        try:
+            transformed_count = transform_reviewed_results_to_labeled(results, labeled_dir, image_dir)
+            if transformed_count > 0:
+                print(f"[✓] Auto-transformed {transformed_count} files to labeled directory")
+
+        except Exception as e:
+            print(f"[Warning] Failed to auto-transform results: {e}")
+
         return results
 
     except requests.exceptions.RequestException as e:
         print(f"[Error] Failed to export results: {e}")
         return {}
+
+
+def _extract_confidence_from_results(export_result, bbox_index):
+    """
+    Extract confidence info from original prediction metadata.
+
+    Args:
+        export_result (dict): Single result from Label Studio export
+        bbox_index (int): Index of the bounding box
+
+    Returns:
+        tuple: (confidence, confidence_flag)
+    """
+    annotations = export_result.get("annotations", [])
+    if not annotations:
+        return 1.0, "human"
+
+    latest_annotation = annotations[-1]
+
+    # Check if there's prediction data in the annotation
+    if "prediction" in latest_annotation:
+        prediction = latest_annotation["prediction"]
+        result_items = prediction.get("result", [])
+        if bbox_index < len(result_items):
+            prediction_item = result_items[bbox_index]
+            meta = prediction_item.get("meta", {})
+            confidence = meta.get("confidence", 1.0)
+            confidence_flag = meta.get("confidence_flag", "human")
+            return confidence, confidence_flag
+
+    return 1.0, "human"
+
+
+def _transform_ls_result_to_original_format(export_result, image_dir: Path):
+    """
+    Transform Label Studio export result back to original JSON format.
+
+    Args:
+        export_result (dict): Single result from Label Studio export
+        image_dir (Path): Directory containing images
+
+    Returns:
+        dict: Transformed data or None if failed
+    """
+    try:
+        # Get annotations from export result
+        annotations = export_result.get("annotations", [])
+        if not annotations:
+            return None
+
+        latest_annotation = annotations[-1]
+        if latest_annotation.get("was_cancelled", False):
+            return None
+
+        # Extract filename info
+        original_filename = export_result["data"].get("original_filename")
+        if not original_filename:
+            return None
+
+        # Transform annotations to original format
+        predictions = []
+        result_items = latest_annotation.get("result", [])
+
+        for idx, annotation_item in enumerate(result_items):
+            if annotation_item.get("type") == "rectanglelabels" and "value" in annotation_item:
+                value = annotation_item["value"]
+                labels = value.get("rectanglelabels", [])
+
+                if not labels:
+                    continue
+
+                # Get image dimensions from annotation
+                img_width = annotation_item.get("original_width")
+                img_height = annotation_item.get("original_height")
+
+                if not img_width or not img_height:
+                    continue
+
+                # Convert bbox from percentage to pixels
+                bbox_pixels = _convert_bbox_from_percent(value, img_width, img_height)
+
+                # Get confidence from original prediction
+                confidence, confidence_flag = _extract_confidence_from_results(export_result, idx)
+
+                prediction = {
+                    "bbox": bbox_pixels,
+                    "confidence": confidence,
+                    "class": labels[0],
+                    "confidence_flag": confidence_flag
+                }
+                predictions.append(prediction)
+
+        return {
+            "data": {
+                "predictions": predictions,
+                "label_status": 2,
+                "reviewed_timestamp": latest_annotation.get("updated_at"),
+                "annotation_id": latest_annotation.get("id"),
+                "result_id": export_result.get("id")
+            },
+            "original_filename": original_filename
+        }
+
+    except Exception as e:
+        print(f"[Error] Failed to transform {export_result.get('id')}: {e}")
+        return None
 
 
 def import_tasks_to_project(base_url: str, headers: Dict[str, str],
@@ -641,6 +785,61 @@ def import_tasks_to_project(base_url: str, headers: Dict[str, str],
     except (requests.RequestException, IOError) as e:
         print(f"[Error] Failed to import tasks: {e}")
         return False
+
+
+def transform_reviewed_results_to_labeled(export_results: list,
+                                          labeled_dir: Path = None,
+                                          image_dir: Path = None) -> int:
+    """
+    Transform reviewed Label Studio results to labeled directory.
+    Removes original pending files and saves human-reviewed data.
+
+    Args:
+        export_results (list): List of results from Label Studio export
+        labeled_dir (Path): Directory to save labeled files
+        image_dir (Path): Directory containing images
+
+    Returns:
+        int: Number of files transformed
+    """
+    if labeled_dir is None:
+        labeled_dir = Path("mock_io/data/labeled")
+    if image_dir is None:
+        image_dir = Path("mock_io/data/raw/images")
+    transformed_count = 0
+
+    # Transform results to original format
+    for export_result in export_results:
+        if not export_result.get("annotations"):
+            continue
+
+        transformed = _transform_ls_result_to_original_format(export_result, image_dir)
+        if not transformed:
+            continue
+
+        original_filename = transformed["original_filename"]
+        labeled_file = labeled_dir / original_filename
+
+        # Skip if file exists in labeled/
+        if labeled_file.exists():
+            continue
+
+        try:
+            # Save human-corrected data to labeled directory
+            with open(labeled_file, 'w') as f:
+                json.dump(transformed["data"], f, indent=2)
+
+            # Remove original file from pending directory
+            pending_file = mismatch_pending_dir / original_filename
+            if pending_file.exists():
+                pending_file.unlink()
+            transformed_count += 1
+
+        except Exception as e:
+            print(f"[Error] Failed to save {original_filename}: {e}")
+
+    print(f"[✓] Transformed {transformed_count} new labeled files")
+    return transformed_count
 
 
 def run_human_review(project_name: str = "AutoML-Human-Intervention",

--- a/src/pipeline/prelabelling/matching.py
+++ b/src/pipeline/prelabelling/matching.py
@@ -60,7 +60,7 @@ def match_and_filter(
     """
     Compare YOLO and DINO predictions for each image.
     Save YOLO prediction files to `labeled_dir` if they match DINO confidently.
-    Save unmatched/mismatched files to `pending_dir` with label_status = 0 for review.
+    Save unmatched/mismatched files to `pending_dir` for review.
 
     Thresholds and behavior are controlled via config dictionary.
     """
@@ -135,7 +135,6 @@ def match_and_filter(
             if is_mismatch:
                 # Add label_status = 0 to each YOLO object for review
                 for obj in yolo_preds:
-                    obj["label_status"] = 0
 
                     conf = obj["confidence"]
                     if conf < low_conf:
@@ -144,7 +143,6 @@ def match_and_filter(
                         obj["confidence_flag"] = "mid"
                     else:
                         obj["confidence_flag"] = "high"
-
 
                 with open(pending_dir / filename, "w") as f:
                     json.dump({"predictions": yolo_preds}, f, indent=2)


### PR DESCRIPTION
## Overview

I updated the `human_intervention.py` script, so that the raw exported results from Label Studio can be automatically transformed back to the original JSON prediction format. Now everytime you run `python src/pipeline/human_intervention.py` and complete a round of review, the human-labeled image jsons (with the corrected bounding boxes coordinates) will be saved at `labeled`. The original jsons in `mismatch/pending` will no longer exist.

## Data Dir Structure

```
mock_io/
├── data/
│   ├── mismatched/
│   │   ├── pending/               <- JSON files for review (reviewed ones will be deleted and moved to `labeled`)
│   │   └── reviewed_results/      <- Export results appear here
│   ├── raw/
│   │   └── images/                <- Original images referenced by JSON files
│   ├── ls_tasks/                  <- Label Studio task files (used for imports)
│   └── labeled/                   <- Human reviewed JSON files will be moved here 
.env
```

## Usage

**Set up the Label Studio API key:**

1. Start Label Studio: `label-studio start`.
2. In the web UI, go to: **☰ Hamburger menu** → **Organization** → **API Token Settings**.
3. If **Legacy Tokens** are not enabled, turn them on.
4. Then navigate to: Top-right → **Account & Settings** → **Legacy Token**.
5. Copy the token and create a `.env` file in the project root with the following content: `LABEL_STUDIO_API_KEY=your_token_here`.

**Run the full review pipeline via:**

```bash
# Run without export
python src/pipeline/human_intervention.py

# Run and immediately export after human review
python src/pipeline/human_intervention.py --export
```

**Review in Label Studio**

- Follow the URL shown in terminal (`http://localhost:8080/projects/...`)
- Review bounding boxes and assign labels
- Press Enter in terminal to finish once labeling is done

You should find the latest reviewed jsons in the `labeled` dir, which is no longer available in the `mismatched/pending` dir.

> **Note:** The `label_status=0` initialization was removed from `matching.py`. Because files are automatically assigned `label_status=0` when first processed by `human_intervention.py`.