### PR TITLE
Add options for user to select which process is needed(HITL, training, distillation, and quantization)

### DIFF
--- a/automl_workspace/config/pipeline_config.json
+++ b/automl_workspace/config/pipeline_config.json
@@ -1,4 +1,10 @@
 {
+  "process_options": {
+    "skip_human_review": false,
+    "skip_training": false,
+    "skip_distillation": false,
+    "skip_quantization": false
+  },
   "distillation_image_prop": 0.2,
   "torch_device": "cpu",
   "iou_threshold": 0.5,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   capstone:
     image: celt313/automl_capstone:v0.0.2
-    shm_size: "4gb"
+    ipc: host
     container_name: automl_capstone
     working_dir: /app
     entrypoint: bash

--- a/src/main.py
+++ b/src/main.py
@@ -9,16 +9,18 @@ from pathlib import Path
 
 from ultralytics.utils import YAML
 
-from pipeline.fetch_data import validate_input_images
-from pipeline.prelabelling.yolo_prelabelling import generate_yolo_prelabelling
-from pipeline.prelabelling.grounding_dino_prelabelling import generate_gd_prelabelling
-from pipeline.prelabelling.matching import match_and_filter
-from pipeline.human_intervention import run_human_review
-from pipeline.augmentation import augment_dataset
-from pipeline.train import train_model
-from pipeline.distillation.distillation import start_distillation
-from pipeline.quantization import quantize_model
-from pipeline.save_model import register_models
+from pipeline import (
+    validate_input_images,
+    generate_yolo_prelabelling,
+    generate_gd_prelabelling,
+    match_and_filter,
+    run_human_review,
+    augment_dataset,
+    train_model,
+    start_distillation,
+    quantize_model,
+    register_models
+)
 from directory_setup import create_automl_workspace
 from utils import load_config, prepare_training_data, detect_device
 
@@ -26,10 +28,11 @@ from utils import load_config, prepare_training_data, detect_device
 SCRIPT_DIR = Path(__file__).parent
 PROJECT_ROOT = SCRIPT_DIR.parent
 
+
 def parse_args():
     """
     Parse command line arguments.
-    
+
     Returns:
         argparse.Namespace: Parsed command line arguments
     """
@@ -37,14 +40,10 @@ def parse_args():
     parser.add_argument(
         '--config',
         type=str,
-        help='Path to the pipeline configuration file (default: pipeline_config.json in the same directory as main.py)'
-    )
-    parser.add_argument(
-        '--skip-human-review',
-        action='store_true',
-        help='Skip human intervention and continue with automated pipeline'
+        help='Path to the pipeline configuration file (default: pipeline_config.json in config directory)'
     )
     return parser.parse_args()
+
 
 def main():
     """
@@ -71,6 +70,20 @@ def main():
 
     config = load_config(pipeline_config_path)
 
+    # Get process options from config
+    process_options = config.get("process_options", {})
+    skip_human_review = process_options.get("skip_human_review", False)
+    skip_training = process_options.get("skip_training", False)
+    skip_distillation = process_options.get("skip_distillation", False)
+    skip_quantization = process_options.get("skip_quantization", False)
+
+    print(" --- PIPELINE CONFIGURATION --- ")
+    print(f"Human Review: {'Disabled' if skip_human_review else 'Enabled'}")
+    print(f"Training: {'Disabled' if skip_training else 'Enabled'}")
+    print(f"Distillation: {'Disabled' if skip_distillation else 'Enabled'}")
+    print(f"Quantization: {'Disabled' if skip_quantization else 'Enabled'}")
+    print("-----------------------------------------------\n")
+
     # Training configuration
     train_config_path = config_dir / "train_config.json"
     train_config = load_config(train_config_path)
@@ -94,7 +107,10 @@ def main():
     quantization_dir = data_pipeline_dir / "quantization"
 
     # Model paths
-    model_path = model_registry_dir / "model" / "nano_trained_model.pt"
+    base_model_path = model_registry_dir / "model" / "nano_trained_model.pt"
+    trained_model_path = None
+    distilled_model_path = None
+    quantized_model_path = None
     distilled_output_dir = model_registry_dir / "distilled"
     quantized_output_dir = model_registry_dir / "quantized"
 
@@ -103,6 +119,9 @@ def main():
     pending_dir = label_studio_dir / "pending"
     tasks_dir = label_studio_dir / "tasks"
     results_dir = label_studio_dir / "results"
+
+    # Track the current model in pipeline
+    current_model_path = base_model_path
 
     print(" --- Step 1: Validating images in input folder --- ")
     # 1. Validate images in input folder
@@ -114,15 +133,15 @@ def main():
 
     print("-----------------------------------------------\n")
     print(" --- Step 2: Generating YOLO prelabelling --- ")
-    
+
     # 2. Generate predictions for raw images
     generate_yolo_prelabelling(
         raw_dir=source_dir,
         output_dir=prelabelled_dir / "yolo",
-        model_path=model_path,
+        model_path=base_model_path,
         config=config
     )
-    
+
     print("-----------------------------------------------\n")
     print(" --- Step 3: Generating Grounding DINO prelabelling --- ")
 
@@ -151,8 +170,8 @@ def main():
     print(" --- Step 5: Human intervention --- ")
 
     # 5. Human intervention
-    if args.skip_human_review:
-        print("[Info] Skipping human review and continuing with automated pipeline...")
+    if skip_human_review:
+        print("[Info] Human review is disabled, skipping...")
     else:
         from dotenv import load_dotenv
         load_dotenv()
@@ -185,59 +204,80 @@ def main():
     print(" --- Step 7: Model training --- ")
 
     # 7. Model training
-    prepare_training_data(config)
-    model_path = train_model(train_config)
+    if skip_training:
+        print("[Info] Training is disabled, skipping...")
+    else:
+        prepare_training_data(config)
+        trained_model_path = train_model(train_config)
+        current_model_path = trained_model_path
 
     print("-----------------------------------------------\n")
     print(" --- Step 8: Model Distillation --- ")
 
     # 8. Model Distillation
-    # Define distillation hyperparameters
-    distillation_hyperparams = {
-        "lambda_distillation": 2.0,
-        "lambda_detection": 1.0,
-        "lambda_dist_ciou": 1.0,
-        "lambda_dist_kl": 2.0,
-        "temperature": 2.0
-    }
-    
-    # Start distillation process
-    start_distillation(
-        device=config.get("torch_device", "cpu") if config.get("torch_device", "cpu") else detect_device(),
-        base_dir=SCRIPT_DIR,
-        img_dir=distillation_dir / "distillation_dataset",
-        frozen_layers=10,  # Freeze backbone layers
-        save_checkpoint_every=25,
-        hyperparams=distillation_hyperparams,
-        resume_checkpoint=None,  # Can be set to resume from a checkpoint if needed
-        output_dir=distilled_output_dir,
-        final_model_dir=distilled_output_dir / "latest",
-        log_level="batch",
-        debug=False,
-        distillation_config=distillation_config,
-        pipeline_config=config
-    )
-    
-    # Get the path to the distilled model
-    distilled_model_path = distilled_output_dir / "latest" / "model.pt"
+    if skip_distillation:
+        print("[Info] Distillation is disabled, skipping...")
+    else:
+        # Define distillation hyperparameters
+        distillation_hyperparams = {
+            "lambda_distillation": 2.0,
+            "lambda_detection": 1.0,
+            "lambda_dist_ciou": 1.0,
+            "lambda_dist_kl": 2.0,
+            "temperature": 2.0
+        }
+
+        # Start distillation process using current model
+        start_distillation(
+            device=config.get("torch_device", "cpu") if config.get("torch_device", "cpu") else detect_device(),
+            base_dir=SCRIPT_DIR,
+            img_dir=distillation_dir / "distillation_dataset",
+            frozen_layers=10,  # Freeze backbone layers
+            save_checkpoint_every=25,
+            hyperparams=distillation_hyperparams,
+            resume_checkpoint=None,  # Can be set to resume from a checkpoint if needed
+            output_dir=distilled_output_dir,
+            final_model_dir=distilled_output_dir / "latest",
+            log_level="batch",
+            debug=False,
+            distillation_config=distillation_config,
+            pipeline_config=config
+        )
+
+        # Get the path to the distilled model
+        distilled_model_path = distilled_output_dir / "latest" / "model.pt"
+        current_model_path = distilled_model_path
 
     print("-----------------------------------------------\n")
     print(" --- Step 9: Model quantization --- ")
     # 9. Model quantization
-    quantized_model_path = quantize_model(
-        model_path=str(distilled_model_path),
-        quantize_config_path=str(quantize_config_path)
-    )
+    if skip_quantization:
+        print("[Info] Quantization is disabled, skipping...")
+    else:
+        quantized_model_path = quantize_model(
+            model_path=str(current_model_path),
+            quantize_config_path=str(quantize_config_path)
+        )
 
     print("-----------------------------------------------\n")
     print(" --- Step 10: Model registration --- ")
 
     # 10. Model registration
+    print("[Info] Registering models:")
+    print(f"Base model: {base_model_path}")
+    if trained_model_path:
+        print(f"Trained model: {trained_model_path}")
+    if distilled_model_path:
+        print(f"Distilled model: {distilled_model_path}")
+    if quantized_model_path:
+        print(f"Quantized model: {quantized_model_path}")
+
     register_models(
-        full_model=model_path,
+        full_model=trained_model_path,
         distilled_model=distilled_model_path,
         quantized_model=quantized_model_path
     )
+
 
 if __name__ == "__main__":
     main()

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from ultralytics.utils import YAML
 
-from pipeline.fetch_data import fetch_and_organize_images
+from pipeline.fetch_data import validate_input_images
 from pipeline.prelabelling.yolo_prelabelling import generate_yolo_prelabelling
 from pipeline.prelabelling.grounding_dino_prelabelling import generate_gd_prelabelling
 from pipeline.prelabelling.matching import match_and_filter
@@ -98,16 +98,9 @@ def main():
     tasks_dir = label_studio_dir / "tasks"
     results_dir = label_studio_dir / "results"
 
-    print(" --- Step 1: Fetching images from input folder --- ")
-    # 1. Fetch images from input folder
-    image_extensions = {'.jpg', '.jpeg', '.png', '.bmp', '.tiff'}
-    images = [f for f in source_dir.glob('*') if f.is_file() and f.suffix.lower() in image_extensions]
-    print(f"Found {len(images)} images in {source_dir}")
-
-    if len(images) == 0:
-        print("[ERROR] No images found in input directory.\
-            Please add images to automl_workspace/data_pipeline/input/")
-        return
+    print(" --- Step 1: Validating images in input folder --- ")
+    # 1. Validate images in input folder
+    validate_input_images(input_dir=source_dir)
 
     print("-----------------------------------------------\n")
     print(" --- Step 2: Generating YOLO prelabelling --- ")

--- a/src/main.py
+++ b/src/main.py
@@ -100,7 +100,11 @@ def main():
 
     print(" --- Step 1: Validating images in input folder --- ")
     # 1. Validate images in input folder
-    validate_input_images(input_dir=source_dir)
+    try:
+        validate_input_images(input_dir=source_dir)
+    except ValueError as e:
+        print(f"[ERROR] {e}")
+        return
 
     print("-----------------------------------------------\n")
     print(" --- Step 2: Generating YOLO prelabelling --- ")

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -1,0 +1,23 @@
+from .fetch_data import validate_input_images
+from .prelabelling.yolo_prelabelling import generate_yolo_prelabelling
+from .prelabelling.grounding_dino_prelabelling import generate_gd_prelabelling
+from .prelabelling.matching import match_and_filter
+from .human_intervention import run_human_review
+from .augmentation import augment_dataset
+from .train import train_model
+from .distillation.distillation import start_distillation
+from .quantization import quantize_model
+from .save_model import register_models
+
+__all__ = [
+    'validate_input_images',
+    'generate_yolo_prelabelling',
+    'generate_gd_prelabelling',
+    'match_and_filter',
+    'run_human_review',
+    'augment_dataset',
+    'train_model',
+    'start_distillation',
+    'quantize_model',
+    'register_models'
+]

--- a/src/pipeline/fetch_data.py
+++ b/src/pipeline/fetch_data.py
@@ -12,95 +12,117 @@ import os
 # Add parent directory to path to import utils
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-def _create_directory_structure(raw_dir: Path, distilled_dir: Path) -> None:
-    """
-    Creates necessary directories for raw and distilled images if they don't exist.
-    
-    Args:
-        raw_dir (Path): Path to raw images directory
-        distilled_dir (Path): Path to distilled images directory
-    """
-    raw_dir.mkdir(parents=True, exist_ok=True)
-    distilled_dir.mkdir(parents=True, exist_ok=True)
 
-def _load_images(source_dir: Path) -> List[Path]:
+def validate_input_images(input_dir: Path) -> None:
     """
-    Loads all image files from the source directory.
-    
+    Validate that images exist in the input directory.
+
     Args:
-        source_dir (Path): Path to directory containing images
-        
-    Returns:
-        List[Path]: List of paths to image files
+        input_dir (Path): Path to input directory containing images
+
+    Raises:
+        ValueError: If no images are found in the source directory
     """
+    # Load all images with supported extensions
     image_extensions = {'.jpg', '.jpeg', '.png', '.bmp', '.tiff'}
-    return [f for f in source_dir.glob('**/*') if f.suffix.lower() in image_extensions]
+    images = [f for f in input_dir.glob('*') if f.is_file() and f.suffix.lower() in image_extensions]
 
-def _save_images_to_raw(images: List[Path], raw_dir: Path) -> None:
-    """
-    Copies images to the raw images directory.
-    
-    Args:
-        images (List[Path]): List of image paths to copy
-        raw_dir (Path): Destination directory for raw images
-    """
-    for img_path in images:
-        dest_path = raw_dir / img_path.name
-        shutil.copy2(img_path, dest_path)
+    # Check if any images were found
+    if len(images) == 0:
+        raise ValueError(f"No images found in input directory. Please add images to {input_dir}")
 
-def _sample_and_save_distilled(images: List[Path], distilled_dir: Path, sample_size: Union[int, float], seed: Optional[int] = 42) -> int:
-    """
-    Samples a subset of images and saves them to the distilled directory.
-    
-    Args:
-        images (List[Path]): List of image paths to sample from
-        distilled_dir (Path): Destination directory for distilled images
-        sample_size (Union[int, float]): Number of images to sample (int) or proportion (float)
-        seed (Optional[int]): Random seed for reproducibility
-        
-    Returns:
-        int: Number of images actually sampled and saved
-    """
-    random.seed(seed)
-    
-    # Calculate actual sample size based on type
-    if isinstance(sample_size, float):
-        actual_sample_size = int(len(images) * sample_size)
-    else:
-        actual_sample_size = min(sample_size, len(images))
-        
-    sampled_images = random.sample(images, actual_sample_size)
-    for img_path in sampled_images:
-        dest_path = distilled_dir / img_path.name
-        shutil.copy2(img_path, dest_path)
-        
-    return actual_sample_size
+    print(f"Found {len(images)} images in {input_dir}")
 
-def fetch_and_organize_images(source_dir: Path, raw_dir: Path, distilled_dir: Path, config: Dict, seed: Optional[int] = None) -> None:
-    """
-    Main function to fetch images from source, save to raw directory, and create a distilled subset.
+
+# def _create_directory_structure(raw_dir: Path, distilled_dir: Path) -> None:
+#     """
+#     Creates necessary directories for raw and distilled images if they don't exist.
     
-    Args:
-        source_dir (Path): Path to source directory containing images
-        raw_dir (Path): Path to save all raw images
-        distilled_dir (Path): Path to save sampled distilled images
-        config (Dict): Configuration dictionary containing pipeline parameters
-        seed (Optional[int]): Random seed for reproducibility
-    """
-    # Create necessary directories
-    _create_directory_structure(raw_dir, distilled_dir)
+#     Args:
+#         raw_dir (Path): Path to raw images directory
+#         distilled_dir (Path): Path to distilled images directory
+#     """
+#     raw_dir.mkdir(parents=True, exist_ok=True)
+#     distilled_dir.mkdir(parents=True, exist_ok=True)
+
+# def _load_images(source_dir: Path) -> List[Path]:
+#     """
+#     Loads all image files from the source directory.
     
-    # Load all images
-    images = _load_images(source_dir)
-    print(f"Found {len(images)} images in source directory")
+#     Args:
+#         source_dir (Path): Path to directory containing images
+        
+#     Returns:
+#         List[Path]: List of paths to image files
+#     """
+#     image_extensions = {'.jpg', '.jpeg', '.png', '.bmp', '.tiff'}
+#     return [f for f in source_dir.glob('**/*') if f.suffix.lower() in image_extensions]
+
+# def _save_images_to_raw(images: List[Path], raw_dir: Path) -> None:
+#     """
+#     Copies images to the raw images directory.
     
-    # Save to raw directory
-    _save_images_to_raw(images, raw_dir)
-    print(f"Saved {len(images)} images to raw directory")
+#     Args:
+#         images (List[Path]): List of image paths to copy
+#         raw_dir (Path): Destination directory for raw images
+#     """
+#     for img_path in images:
+#         dest_path = raw_dir / img_path.name
+#         shutil.copy2(img_path, dest_path)
+
+# def _sample_and_save_distilled(images: List[Path], distilled_dir: Path, sample_size: Union[int, float], seed: Optional[int] = 42) -> int:
+#     """
+#     Samples a subset of images and saves them to the distilled directory.
     
-    # Sample and save to distilled directory if distillation is enabled
-    if config.get("distillation_image_prop", 0) > 0:
-        num_sampled = _sample_and_save_distilled(images, distilled_dir, config["distillation_image_prop"], seed)
-        print(f"Sampled and saved {num_sampled} images to distilled directory")
-    else:
-        print("Skipping distillation set creation as per configuration") 
+#     Args:
+#         images (List[Path]): List of image paths to sample from
+#         distilled_dir (Path): Destination directory for distilled images
+#         sample_size (Union[int, float]): Number of images to sample (int) or proportion (float)
+#         seed (Optional[int]): Random seed for reproducibility
+        
+#     Returns:
+#         int: Number of images actually sampled and saved
+#     """
+#     random.seed(seed)
+    
+#     # Calculate actual sample size based on type
+#     if isinstance(sample_size, float):
+#         actual_sample_size = int(len(images) * sample_size)
+#     else:
+#         actual_sample_size = min(sample_size, len(images))
+        
+#     sampled_images = random.sample(images, actual_sample_size)
+#     for img_path in sampled_images:
+#         dest_path = distilled_dir / img_path.name
+#         shutil.copy2(img_path, dest_path)
+        
+#     return actual_sample_size
+
+# def fetch_and_organize_images(source_dir: Path, raw_dir: Path, distilled_dir: Path, config: Dict, seed: Optional[int] = None) -> None:
+#     """
+#     Main function to fetch images from source, save to raw directory, and create a distilled subset.
+    
+#     Args:
+#         source_dir (Path): Path to source directory containing images
+#         raw_dir (Path): Path to save all raw images
+#         distilled_dir (Path): Path to save sampled distilled images
+#         config (Dict): Configuration dictionary containing pipeline parameters
+#         seed (Optional[int]): Random seed for reproducibility
+#     """
+#     # Create necessary directories
+#     _create_directory_structure(raw_dir, distilled_dir)
+    
+#     # Load all images
+#     images = _load_images(source_dir)
+#     print(f"Found {len(images)} images in source directory")
+    
+#     # Save to raw directory
+#     _save_images_to_raw(images, raw_dir)
+#     print(f"Saved {len(images)} images to raw directory")
+    
+#     # Sample and save to distilled directory if distillation is enabled
+#     if config.get("distillation_image_prop", 0) > 0:
+#         num_sampled = _sample_and_save_distilled(images, distilled_dir, config["distillation_image_prop"], seed)
+#         print(f"Sampled and saved {num_sampled} images to distilled directory")
+#     else:
+#         print("Skipping distillation set creation as per configuration") 

--- a/tests/test_augmentation.py
+++ b/tests/test_augmentation.py
@@ -105,15 +105,19 @@ def test_augment_dataset_integration(tmp_path, sample_config, temp_image_and_jso
     image_dir.mkdir()
     shutil.copy(temp_image_and_json[0][1], image_dir / "test_image.jpg")
 
-    # Patch mock_io/data/labeled to point to the label file
-    mock_labeled = Path("mock_io/data/labeled")
-    mock_labeled.mkdir(parents=True, exist_ok=True)
-    shutil.copy(temp_image_and_json[0][0], mock_labeled / "test_image.json")
+    # Patch automl_workspace/data_pipeline/labeled to point to the label file
+    labeled_dir = Path("automl_workspace/data_pipeline/labeled")
+    labeled_dir.mkdir(parents=True, exist_ok=True)
+    test_json_file = labeled_dir / "test_image.json"
+    shutil.copy(temp_image_and_json[0][0], test_json_file)
 
-    augment_dataset(image_dir, output_dir, sample_config)
+    try:
+        augment_dataset(image_dir, output_dir, sample_config)
 
-    assert (output_dir / "images").exists()
-    assert (output_dir / "labels").exists()
-
-    assert len(list((output_dir / "images").glob("*.jpg"))) >= 1
-    assert len(list((output_dir / "labels").glob("*.json"))) >= 1
+        assert (output_dir / "images").exists()
+        assert (output_dir / "labels").exists()
+        assert len(list((output_dir / "images").glob("*.jpg"))) >= 1
+        assert len(list((output_dir / "labels").glob("*.json"))) >= 1
+    finally:
+        if test_json_file.exists():
+            test_json_file.unlink()

--- a/tests/test_directory_setup.py
+++ b/tests/test_directory_setup.py
@@ -1,0 +1,122 @@
+"""
+Tests for the directory_setup module.
+"""
+import os
+from unittest.mock import patch
+from src.directory_setup import create_automl_workspace
+
+
+def test_create_automl_workspace_default_path(tmp_path):
+    """Test creating automl_workspace with default path."""
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        create_automl_workspace()
+
+        # Verify workspace was created
+        workspace_dir = tmp_path / "automl_workspace"
+        assert workspace_dir.exists()
+        assert workspace_dir.is_dir()
+
+        # Verify subdirectories exist
+        expected_dirs = [
+            "data_pipeline/input",
+            "data_pipeline/prelabeled",
+            "data_pipeline/labeled",
+            "data_pipeline/augmented",
+            "data_pipeline/training",
+            "data_pipeline/distillation",
+            "data_pipeline/quantization",
+            "data_pipeline/label_studio/pending",
+            "data_pipeline/label_studio/tasks",
+            "data_pipeline/label_studio/results",
+            "model_registry/model",
+            "model_registry/distilled",
+            "model_registry/quantized",
+            "master_dataset",
+            "config"
+        ]
+
+        for subdir in expected_dirs:
+            dir_path = workspace_dir / subdir
+            assert dir_path.exists(), f"Directory {subdir} was not created"
+            assert dir_path.is_dir(), f"{subdir} is not a directory"
+
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_create_automl_workspace_custom_path(tmp_path):
+    """Test creating automl_workspace with custom base path."""
+    custom_base = tmp_path / "custom_location"
+    custom_base.mkdir()
+
+    create_automl_workspace(str(custom_base))
+
+    # Verify workspace was created in custom location
+    workspace_dir = custom_base / "automl_workspace"
+    assert workspace_dir.exists()
+
+    # Verify key directories
+    assert (workspace_dir / "data_pipeline" / "input").exists()
+    assert (workspace_dir / "model_registry" / "model").exists()
+    assert (workspace_dir / "config").exists()
+
+
+def test_create_automl_workspace_already_exists(tmp_path):
+    """Test that function handles existing directories gracefully."""
+    create_automl_workspace(str(tmp_path))
+
+    # Create test file
+    test_file = tmp_path / "automl_workspace" / "config" / "test.txt"
+    test_file.write_text("test content")
+
+    create_automl_workspace(str(tmp_path))
+
+    # Verify the test file still exists
+    assert test_file.exists()
+    assert test_file.read_text() == "test content"
+
+
+def test_create_automl_workspace_permission_error(tmp_path):
+    """Test handling of permission errors during directory creation."""
+    with patch('os.makedirs') as mock_makedirs:
+        mock_makedirs.side_effect = PermissionError("Permission denied")
+
+        with patch('builtins.print') as mock_print:
+            create_automl_workspace(str(tmp_path))
+
+            assert mock_print.called
+            error_calls = [call for call in mock_print.call_args_list
+                           if "Error creating directory" in str(call)]
+            assert len(error_calls) > 0
+
+
+def test_create_automl_workspace_nested_structure(tmp_path):
+    """Test that nested directory structure is created correctly."""
+    create_automl_workspace(str(tmp_path))
+    workspace_dir = tmp_path / "automl_workspace"
+
+    # Test deep nesting
+    label_studio_pending = workspace_dir / "data_pipeline" / "label_studio" / "pending"
+    assert label_studio_pending.exists()
+    assert label_studio_pending.is_dir()
+
+    # Test parent directories exist
+    assert (workspace_dir / "data_pipeline").exists()
+    assert (workspace_dir / "data_pipeline" / "label_studio").exists()
+
+
+@patch('os.path.exists')
+@patch('os.makedirs')
+def test_create_automl_workspace_makedirs_called_correctly(mock_makedirs, mock_exists):
+    """Test that os.makedirs is called with correct paths."""
+    mock_exists.return_value = False
+    create_automl_workspace("/test/path")
+
+    # Check that makedirs was called for each expected subdirectory
+    made_dirs = [call[0][0] for call in mock_makedirs.call_args_list]
+    assert any("data_pipeline/input" in path for path in made_dirs)
+    assert any("model_registry/model" in path for path in made_dirs)
+    assert any("config" in path for path in made_dirs)

--- a/tests/test_fetch_data.py
+++ b/tests/test_fetch_data.py
@@ -5,132 +5,93 @@ Tests for the fetch_data module.
 import pytest
 from pathlib import Path
 import shutil
-import os
 
-from src.pipeline.fetch_data import (
-    _create_directory_structure,
-    _load_images,
-    _save_images_to_raw,
-    _sample_and_save_distilled,
-    fetch_and_organize_images
-)
+from src.pipeline.fetch_data import validate_input_images
+
 
 @pytest.fixture
 def temp_dirs(tmp_path):
     """Create temporary directories for testing."""
     source_dir = tmp_path / "source"
-    raw_dir = tmp_path / "raw"
-    distilled_dir = tmp_path / "distilled"
-    
+
     # Create source directory with some test images
     source_dir.mkdir()
     for i in range(5):
         (source_dir / f"test_image_{i}.jpg").touch()
         (source_dir / f"test_image_{i}.png").touch()
-    
-    yield source_dir, raw_dir, distilled_dir
-    
+
+    yield source_dir
+
     # Cleanup
-    shutil.rmtree(tmp_path)
+    shutil.rmtree(tmp_path, ignore_errors=True)
 
-def test_create_directory_structure(temp_dirs):
-    """Test directory structure creation."""
-    _, raw_dir, distilled_dir = temp_dirs
-    
-    _create_directory_structure(raw_dir, distilled_dir)
-    
-    assert raw_dir.exists()
-    assert distilled_dir.exists()
-    assert raw_dir.is_dir()
-    assert distilled_dir.is_dir()
 
-def test_load_images(temp_dirs):
-    """Test loading images from source directory."""
-    source_dir, _, _ = temp_dirs
-    
-    images = _load_images(source_dir)
-    
-    assert len(images) == 10  # 5 jpg + 5 png files
-    assert all(img.suffix.lower() in {'.jpg', '.png'} for img in images)
-    assert all(img.exists() for img in images)
+def test_validate_input_images_success(temp_dirs):
+    """Test validating images when images exist."""
+    source_dir = temp_dirs
 
-def test_save_images_to_raw(temp_dirs):
-    """Test saving images to raw directory."""
-    source_dir, raw_dir, _ = temp_dirs
-    
-    # Create raw directory
-    raw_dir.mkdir()
-    
-    # Load and save images
-    images = _load_images(source_dir)
-    _save_images_to_raw(images, raw_dir)
-    
-    # Check if all images were copied
-    raw_images = list(raw_dir.glob('*'))
-    assert len(raw_images) == len(images)
-    assert all(img.exists() for img in raw_images)
+    # Should not raise an exception
+    validate_input_images(source_dir)
 
-def test_sample_and_save_distilled(temp_dirs):
-    """Test sampling and saving distilled images."""
-    source_dir, _, distilled_dir = temp_dirs
-    
-    # Create distilled directory
-    distilled_dir.mkdir()
-    
-    # Load images
-    images = _load_images(source_dir)
-    
-    # Test with integer sample size
-    num_sampled = _sample_and_save_distilled(images, distilled_dir, 3, seed=42)
-    assert num_sampled == 3
-    assert len(list(distilled_dir.glob('*'))) == 3
-    
-    # Clean distilled directory
-    for file in distilled_dir.glob('*'):
-        file.unlink()
-    
-    # Test with float sample size
-    num_sampled = _sample_and_save_distilled(images, distilled_dir, 0.5, seed=42)
-    assert num_sampled == 5  # 50% of 10 images
-    assert len(list(distilled_dir.glob('*'))) == 5
 
-def test_fetch_and_organize_images(temp_dirs):
-    """Test the main fetch_and_organize_images function."""
-    source_dir, raw_dir, distilled_dir = temp_dirs
-    
-    # Test without distillation
-    config = {"distillation_image_prop": 0}
-    fetch_and_organize_images(source_dir, raw_dir, distilled_dir, config)
-    
-    assert raw_dir.exists()
-    assert len(list(raw_dir.glob('*'))) == 10
-    # Check that distilled directory exists but is empty
-    assert distilled_dir.exists()
-    assert len(list(distilled_dir.glob('*'))) == 0
-    
-    # Clean up
-    shutil.rmtree(raw_dir)
-    shutil.rmtree(distilled_dir)
-    
-    # Test with distillation
-    config = {"distillation_image_prop": 0.3}
-    fetch_and_organize_images(source_dir, raw_dir, distilled_dir, config, seed=42)
-    
-    assert raw_dir.exists()
-    assert distilled_dir.exists()
-    assert len(list(raw_dir.glob('*'))) == 10
-    assert len(list(distilled_dir.glob('*'))) == 3  # 30% of 10 images
-
-def test_invalid_source_directory():
-    """Test behavior with invalid source directory."""
-    # The function should return an empty list for non-existent directory
-    images = _load_images(Path("nonexistent_directory"))
-    assert len(images) == 0
-
-def test_empty_source_directory(tmp_path):
-    """Test behavior with empty source directory."""
+def test_validate_input_images_empty_directory(tmp_path):
+    """Test validating images with empty directory."""
     empty_dir = tmp_path / "empty"
     empty_dir.mkdir()
-    
-    images = _load_images(empty_dir)
-    assert len(images) == 0 
+
+    # Should raise ValueError
+    with pytest.raises(ValueError, match="No images found in input directory"):
+        validate_input_images(empty_dir)
+
+
+def test_validate_input_images_no_valid_images(tmp_path):
+    """Test validating directory with no valid image files."""
+    dir_with_text = tmp_path / "text_only"
+    dir_with_text.mkdir()
+
+    (dir_with_text / "readme.txt").touch()
+    (dir_with_text / "data.csv").touch()
+    (dir_with_text / "config.json").touch()
+
+    # Non-image files should raise ValueError
+    with pytest.raises(ValueError, match="No images found in input directory"):
+        validate_input_images(dir_with_text)
+
+
+def test_validate_input_images_mixed_files(tmp_path):
+    """Test validating directory with mix of image and non-image files."""
+    mixed_dir = tmp_path / "mixed"
+    mixed_dir.mkdir()
+
+    (mixed_dir / "image1.jpg").touch()
+    (mixed_dir / "image2.png").touch()
+    (mixed_dir / "readme.txt").touch()
+    (mixed_dir / "data.csv").touch()
+
+    # Images exist, should not raise an exception
+    validate_input_images(mixed_dir)
+
+
+def test_validate_input_images_different_extensions(tmp_path):
+    """Test validating images with different supported extensions."""
+    image_dir = tmp_path / "images"
+    image_dir.mkdir()
+
+    (image_dir / "image.jpg").touch()
+    (image_dir / "image.jpeg").touch()
+    (image_dir / "image.png").touch()
+    (image_dir / "image.bmp").touch()
+    (image_dir / "image.tiff").touch()
+    (image_dir / "image.gif").touch()
+
+    # Images supported, should not raise an exception
+    validate_input_images(image_dir)
+
+
+def test_validate_input_images_nonexistent_directory():
+    """Test validating nonexistent directory."""
+    nonexistent_dir = Path("nonexistent_directory")
+
+    # Directory not exist, should raise ValueError
+    with pytest.raises(ValueError, match="No images found in input directory"):
+        validate_input_images(nonexistent_dir)

--- a/tests/test_human_intervention.py
+++ b/tests/test_human_intervention.py
@@ -14,15 +14,18 @@ from src.pipeline.human_intervention import (
     _update_label_status,
     _initialize_json_files,
     _convert_bbox_to_percent,
+    _convert_bbox_from_percent,
     _generate_ls_tasks,
     _update_processed_files_status,
     _ensure_label_studio_running,
     _find_or_create_project,
     _configure_interface,
-    # _connect_local_storage,
     setup_label_studio,
     import_tasks_to_project,
     export_versioned_results,
+    transform_reviewed_results_to_labeled,
+    _transform_ls_result_to_original_format,
+    _extract_confidence_from_results,
     run_human_review
 )
 
@@ -41,18 +44,20 @@ def tmp_path():
 @pytest.fixture(autouse=True)
 def mock_global_directories():
     """Mock the global directory paths to prevent FileNotFoundError during import."""
-    with patch("src.pipeline.human_intervention.mismatch_dir") as mock_mismatch_dir, \
+    with patch("src.pipeline.human_intervention.label_studio_dir") as mock_ls_dir, \
          patch("src.pipeline.human_intervention.mismatch_pending_dir") as mock_pending_dir, \
          patch("src.pipeline.human_intervention.reviewed_dir") as mock_reviewed_dir, \
          patch("src.pipeline.human_intervention.image_dir") as mock_image_dir, \
-         patch("src.pipeline.human_intervention.output_dir") as mock_output_dir:
+         patch("src.pipeline.human_intervention.output_dir") as mock_output_dir, \
+         patch("src.pipeline.human_intervention.labeled_dir") as mock_labeled_dir:
 
         # Configure the mock paths
-        mock_mismatch_dir.mkdir.return_value = None
+        mock_ls_dir.mkdir.return_value = None
         mock_pending_dir.mkdir.return_value = None
         mock_reviewed_dir.mkdir.return_value = None
         mock_image_dir.mkdir.return_value = None
         mock_output_dir.mkdir.return_value = None
+        mock_labeled_dir.mkdir.return_value = None
         yield
 
 
@@ -63,11 +68,13 @@ def temp_dirs(tmp_path):
     image_dir = tmp_path / "images"
     json_dir = tmp_path / "json"
     output_dir = tmp_path / "output"
+    labeled_dir = tmp_path / "labeled"
 
     # Create directories with parents=True
     image_dir.mkdir(parents=True, exist_ok=True)
     json_dir.mkdir(parents=True, exist_ok=True)
     output_dir.mkdir(parents=True, exist_ok=True)
+    labeled_dir.mkdir(parents=True, exist_ok=True)
 
     # Create test images - ensure the files exist by opening and writing
     for i in range(3):
@@ -83,19 +90,19 @@ def temp_dirs(tmp_path):
     for i in range(5):
         json_content = {
             "predictions": [
-                {"bbox": [10, 20, 100, 200], "class": "FireBSI"}
+                {"bbox": [10, 20, 100, 200], "class": "FireBSI", "confidence": 0.85}
             ]
         }
         json_file = json_dir / f"image_{i}.json"
         with open(json_file, "w") as f:
             json.dump(json_content, f)
 
-    yield image_dir, json_dir, output_dir
+    yield image_dir, json_dir, output_dir, labeled_dir
 
 
 def test_find_image_path(temp_dirs):
     """Test finding image path by stem."""
-    image_dir, _, _ = temp_dirs
+    image_dir, _, _, _ = temp_dirs
 
     # Should find existing image
     path = _find_image_path("image_0", image_dir)
@@ -111,7 +118,7 @@ def test_find_image_path(temp_dirs):
 
 def test_update_label_status(temp_dirs):
     """Test updating label status in JSON file."""
-    _, json_dir, _ = temp_dirs
+    _, json_dir, _, _ = temp_dirs
 
     # Create a test JSON file
     file_path = json_dir / "test.json"
@@ -139,7 +146,7 @@ def test_update_label_status_file_not_found(tmp_path):
 
 def test_initialize_json_files(temp_dirs):
     """Test initializing label_status field in JSON files."""
-    _, json_dir, _ = temp_dirs
+    _, json_dir, _, _ = temp_dirs
 
     # Initialize files
     count = _initialize_json_files(json_dir)
@@ -205,15 +212,34 @@ def test_convert_bbox_to_percent():
     assert result["height"] == 15.0
 
 
+def test_convert_bbox_from_percent():
+    """Test converting bounding box from percent format back to pixels."""
+    # Test with 100x100 image
+    bbox_dict = {"x": 10.0, "y": 20.0, "width": 50.0, "height": 60.0}
+    result = _convert_bbox_from_percent(bbox_dict, 100, 100)
+
+    assert result == [10.0, 20.0, 60.0, 80.0]
+
+    # Test with different image dimensions
+    bbox_dict = {"x": 5.0, "y": 5.0, "width": 25.0, "height": 15.0}
+    result = _convert_bbox_from_percent(bbox_dict, 200, 400)
+
+    assert result == [10.0, 20.0, 60.0, 80.0]
+
+
 @patch("PIL.Image.open")
-def test_generate_ls_tasks(mock_image_open, temp_dirs):
+@patch("base64.b64encode")
+def test_generate_ls_tasks(mock_b64encode, mock_image_open, temp_dirs):
     """Test generating Label Studio tasks from JSON files."""
-    image_dir, json_dir, output_dir = temp_dirs
+    image_dir, json_dir, output_dir, _ = temp_dirs
 
     # Mock Image.open to return consistent dimensions
     mock_img = MagicMock()
     mock_img.size = (100, 100)
     mock_image_open.return_value.__enter__.return_value = mock_img
+
+    # Mock base64 encoding
+    mock_b64encode.return_value.decode.return_value = "base64encodedstring"
 
     # Test with files that have no label_status yet
     versioned_file, processed_files = _generate_ls_tasks(json_dir, image_dir, output_dir)
@@ -233,11 +259,15 @@ def test_generate_ls_tasks(mock_image_open, temp_dirs):
         assert "data" in task
         assert "image" in task["data"]
         assert task["data"]["image"].startswith("data:image/")
+        assert "filename" in task["data"]
+        assert "import_timestamp" in task["data"]
+        assert "original_filename" in task["data"]
 
         if "predictions" in task:
             assert isinstance(task["predictions"], list)
             prediction = task["predictions"][0]
             assert "result" in prediction
+            assert "model_version" in prediction
 
     # Test with files that have been imported (status = 1)
     for file in json_dir.glob("*.json"):
@@ -267,7 +297,7 @@ def test_generate_ls_tasks_empty_dir(mock_image_open, tmp_path):
 @patch("PIL.Image.open")
 def test_generate_ls_tasks_missing_images(mock_image_open, temp_dirs):
     """Test handling JSON files with missing corresponding images."""
-    _, json_dir, output_dir = temp_dirs
+    _, json_dir, output_dir, _ = temp_dirs
 
     # Create a non-existent image directory
     missing_img_dir = Path("/non/existent/path")
@@ -283,7 +313,7 @@ def test_generate_ls_tasks_missing_images(mock_image_open, temp_dirs):
 
 def test_update_processed_files_status(temp_dirs):
     """Test updating status of processed files."""
-    _, json_dir, _ = temp_dirs
+    _, json_dir, _, _ = temp_dirs
 
     # List all JSON files
     files_to_update = list(json_dir.glob("*.json"))
@@ -298,10 +328,11 @@ def test_update_processed_files_status(temp_dirs):
             assert data["label_status"] == 1
 
 
+@patch("subprocess.Popen")
 @patch("requests.get")
-def test_ensure_label_studio_running(mock_get):
+def test_ensure_label_studio_running(mock_get, mock_popen):
     """Test checking if Label Studio is running."""
-    # Mock successful response
+    # Mock successful response (already running)
     mock_response = Mock()
     mock_response.status_code = 200
     mock_get.return_value = mock_response
@@ -311,6 +342,24 @@ def test_ensure_label_studio_running(mock_get):
 
     assert result is True
     mock_get.assert_called_once()
+    mock_popen.assert_not_called()
+
+
+@patch("subprocess.Popen")  
+@patch("requests.get")
+def test_ensure_label_studio_running_needs_start(mock_get, mock_popen):
+    """Test starting Label Studio when it's not running."""
+    # Mock failed first request, then successful health check
+    mock_get.side_effect = [
+        Exception("Connection failed"),
+        Mock(status_code=200)
+    ]
+
+    result = _ensure_label_studio_running()
+
+    assert result is True
+    mock_popen.assert_called_once()
+    assert mock_get.call_count >= 2
 
 
 @patch("requests.get")
@@ -365,39 +414,10 @@ def test_configure_interface(mock_patch):
     mock_patch.assert_called_once()
 
 
-# @patch("requests.get")
-# @patch("requests.post")
-# def test_connect_local_storage(mock_post, mock_get):
-#     """Test connecting Label Studio to local storage."""
-#     # Mock responses
-#     mock_get_response = Mock()
-#     mock_get_response.json.return_value = []
-#     mock_get_response.status_code = 200
-#     mock_get.return_value = mock_get_response
-
-#     mock_post_response = Mock()
-#     mock_post_response.json.return_value = {"id": 789}
-#     mock_post_response.status_code = 201
-#     mock_post.return_value = mock_post_response
-
-#     # Test creating new storage
-#     result = _connect_local_storage(
-#         "http://localhost:8080",
-#         {"Authorization": "Token abc123"},
-#         123,
-#         "Test Project",
-#         "/path/to/data"
-#     )
-
-#     assert result == 789
-#     assert mock_post.call_count == 2
-
-
 @patch("requests.post")
-@patch("requests.get")
-def test_import_tasks_to_project(mock_get, mock_post, temp_dirs):
+def test_import_tasks_to_project(mock_post, temp_dirs):
     """Test importing tasks to Label Studio project."""
-    _, _, output_dir = temp_dirs
+    _, _, output_dir, _ = temp_dirs
 
     # Create test tasks file
     tasks_file = output_dir / "tasks.json"
@@ -437,8 +457,74 @@ def test_setup_label_studio(mock_interface, mock_project):
     }
 
 
+def test_extract_confidence_from_results():
+    """Test extracting confidence from Label Studio results."""
+    # Test with prediction metadata
+    export_result = {
+        "annotations": [{
+            "prediction": {
+                "result": [{
+                    "meta": {
+                        "confidence": 0.85,
+                        "confidence_flag": "high"
+                    }
+                }]
+            }
+        }]
+    }
+
+    confidence, flag = _extract_confidence_from_results(export_result, 0)
+    assert confidence == 0.85
+    assert flag == "high"
+
+    # Test with no annotations
+    export_result = {"annotations": []}
+    confidence, flag = _extract_confidence_from_results(export_result, 0)
+    assert confidence == 1.0
+    assert flag == "human"
+
+
+def test_transform_ls_result_to_original_format():
+    """Test transforming Label Studio results back to original format."""
+    export_result = {
+        "id": 123,
+        "data": {"original_filename": "test.json"},
+        "annotations": [{
+            "id": 456,
+            "updated_at": "2025-01-01T00:00:00Z",
+            "was_cancelled": False,
+            "result": [{
+                "type": "rectanglelabels",
+                "value": {
+                    "x": 10.0,
+                    "y": 20.0,
+                    "width": 50.0,
+                    "height": 60.0,
+                    "rectanglelabels": ["FireBSI"]
+                },
+                "original_width": 100,
+                "original_height": 100
+            }]
+        }]
+    }
+
+    result = _transform_ls_result_to_original_format(export_result, Path("/images"))
+
+    assert result is not None
+    assert result["original_filename"] == "test.json"
+    assert result["data"]["label_status"] == 2
+    assert len(result["data"]["predictions"]) == 1
+
+    prediction = result["data"]["predictions"][0]
+    assert prediction["bbox"] == [10.0, 20.0, 60.0, 80.0]
+    assert prediction["class"] == "FireBSI"
+
+
 @patch("requests.get")
-def test_export_versioned_results(mock_get):
+@patch("pathlib.Path.glob")
+@patch("json.dump")
+@patch("builtins.open", create=True)
+def test_export_versioned_results(mock_open, mock_json_dump, mock_glob, mock_get):
     """Test exporting versioned results from Label Studio."""
     # Mock responses
     tasks_response = Mock()
@@ -471,74 +557,118 @@ def test_export_versioned_results(mock_get):
 
     mock_get.side_effect = [tasks_response, export_response]
 
-    with patch.dict("os.environ", {"LABEL_STUDIO_API_KEY": "test_key"}):
-        with patch("builtins.open", create=True):
-            with patch("json.dump"):
-                with patch("pathlib.Path.glob") as mock_glob:
-                    # Mock glob to return a path
-                    mock_path = Mock()
-                    mock_path.name = "image_0.json"
-                    mock_glob.return_value = [mock_path]
+    # Mock file operations
+    mock_path = Mock()
+    mock_path.name = "image_0.json"
+    mock_glob.return_value = [mock_path]
 
-                    # Test export
-                    results = export_versioned_results(
-                        "123", 
-                        Path("/output/dir"),
-                        "v1"
-                    )
+    with patch.dict("os.environ", {"LABEL_STUDIO_API_KEY": "test_key"}):
+        with patch("src.pipeline.human_intervention._update_label_status") as mock_update:
+            with patch("src.pipeline.human_intervention.transform_reviewed_results_to_labeled") as mock_transform:
+                mock_transform.return_value = 1
+                results = export_versioned_results(
+                    "123", 
+                    Path("/output/dir"),
+                    "v1"
+                )
 
     assert len(results) == 2
     # Check that base64 data was removed
     assert "image" not in results[0]["data"]
+    mock_transform.assert_called_once()
 
 
-@patch("requests.get")
-def test_export_versioned_results_missing_api_key(mock_get):
-    """Test export with missing API key."""
-    # Should return empty dict when API key is missing
-    with patch.dict("os.environ", {}, clear=True):
-        result = export_versioned_results("123", Path("/tmp"))
-    assert result == {}
+@patch("json.dump")
+@patch("builtins.open", create=True)
+@patch("pathlib.Path.unlink")
+@patch("pathlib.Path.exists")
+def test_transform_reviewed_results_to_labeled(mock_exists, mock_unlink, mock_open, mock_json_dump, temp_dirs):
+    """Test transforming reviewed results to labeled directory."""
+    _, _, _, labeled_dir = temp_dirs
+
+    # Mock export results
+    export_results = [{
+        "id": 123,
+        "data": {"original_filename": "test.json"},
+        "annotations": [{
+            "id": 456,
+            "updated_at": "2025-01-01T00:00:00Z",
+            "was_cancelled": False,
+            "result": [{
+                "type": "rectanglelabels",
+                "value": {
+                    "x": 10.0,
+                    "y": 20.0,
+                    "width": 50.0,
+                    "height": 60.0,
+                    "rectanglelabels": ["FireBSI"]
+                },
+                "original_width": 100,
+                "original_height": 100
+            }]
+        }]
+    }]
+
+    # Mock file operations
+    mock_exists.return_value = False
+
+    with patch("src.pipeline.human_intervention.mismatch_pending_dir") as mock_pending:
+        mock_pending_file = Mock()
+        mock_pending_file.exists.return_value = True
+        mock_pending.__truediv__.return_value = mock_pending_file
+
+        count = transform_reviewed_results_to_labeled(
+            export_results, 
+            labeled_dir, 
+            Path("/images")
+        )
+
+    assert count == 1
+    mock_json_dump.assert_called_once()
+    mock_pending_file.unlink.assert_called_once()
 
 
 @patch("src.pipeline.human_intervention.setup_label_studio")
 @patch("src.pipeline.human_intervention._ensure_label_studio_running")
+@patch("src.pipeline.human_intervention._ensure_directories")
 @patch("src.pipeline.human_intervention._initialize_json_files")
 @patch("src.pipeline.human_intervention._generate_ls_tasks")
 @patch("src.pipeline.human_intervention.import_tasks_to_project")
 @patch("src.pipeline.human_intervention._update_processed_files_status")
+@patch("pathlib.Path.glob")
 def test_run_human_review(
-    mock_update_status, mock_import, mock_generate, mock_initialize, 
-    mock_ensure_running, mock_setup
+    mock_glob, mock_update_status, mock_import, mock_generate, mock_initialize, 
+    mock_ensure_dirs, mock_ensure_running, mock_setup
 ):
     """Test running the complete human review workflow."""
     # Setup mocks
     mock_ensure_running.return_value = True
     mock_setup.return_value = {
         "project_id": 123,
-        "storage_id": 789,
+        "storage_id": None,
         "project_url": "http://localhost:8080/projects/123/data"
     }
     mock_generate.return_value = (Path("/tmp/tasks.json"), ["file1.json", "file2.json"])
     mock_import.return_value = True
+    mock_glob.return_value = ["file1.json", "file2.json"]
 
     with patch.dict("os.environ", {"LABEL_STUDIO_API_KEY": "test_key"}):
-        with patch("pathlib.Path.glob") as mock_glob:
-            mock_glob.return_value = ["file1.json", "file2.json"]
-            result = run_human_review("Test Project", export_results_flag=False)
+        result = run_human_review("Test Project", export_results_flag=False)
 
     assert result == {
         "project_id": 123,
-        "storage_id": 789,
+        "storage_id": None,
         "project_url": "http://localhost:8080/projects/123/data"
     }
+    mock_ensure_dirs.assert_called_once()
     mock_update_status.assert_called_once()
 
 
 @patch("src.pipeline.human_intervention.setup_label_studio")
 @patch("src.pipeline.human_intervention._ensure_label_studio_running")
+@patch("src.pipeline.human_intervention._ensure_directories")
 @patch("src.pipeline.human_intervention._initialize_json_files")
-def test_run_human_review_setup_failure(mock_initialize, mock_ensure_running, mock_setup):
+def test_run_human_review_setup_failure(mock_initialize, mock_ensure_dirs, mock_ensure_running, mock_setup):
     """Test run_human_review when setup fails."""
     mock_ensure_running.return_value = True
     mock_setup.return_value = {}
@@ -550,33 +680,10 @@ def test_run_human_review_setup_failure(mock_initialize, mock_ensure_running, mo
     assert result == {}
 
 
-@patch("src.pipeline.human_intervention.setup_label_studio")
 @patch("src.pipeline.human_intervention._ensure_label_studio_running")
+@patch("src.pipeline.human_intervention._ensure_directories")
 @patch("src.pipeline.human_intervention._initialize_json_files")
-@patch("src.pipeline.human_intervention._generate_ls_tasks")
-@patch("src.pipeline.human_intervention.import_tasks_to_project")
-def test_run_human_review_import_failure(
-    mock_import, mock_generate, mock_initialize, mock_ensure_running, mock_setup
-):
-    """Test run_human_review when import fails."""
-    mock_ensure_running.return_value = True
-    mock_setup.return_value = {
-        "project_id": 123,
-        "storage_id": 789,
-        "project_url": "http://localhost:8080/projects/123/data"
-    }
-    mock_generate.return_value = (Path("/tmp/tasks.json"), ["file1.json", "file2.json"])
-    mock_import.return_value = False
-
-    with patch.dict("os.environ", {"LABEL_STUDIO_API_KEY": "test_key"}):
-        result = run_human_review("Test Project", export_results_flag=False)
-
-    # Should still return project details even if import fails
-    assert "project_url" in result
-
-
-@patch("src.pipeline.human_intervention._ensure_label_studio_running")
-def test_run_human_review_no_label_studio(mock_ensure_running):
+def test_run_human_review_no_label_studio(mock_initialize, mock_ensure_dirs, mock_ensure_running):
     """Test running workflow when Label Studio isn't running."""
     mock_ensure_running.return_value = False
 
@@ -584,3 +691,36 @@ def test_run_human_review_no_label_studio(mock_ensure_running):
         result = run_human_review("Test Project", export_results_flag=False)
 
     assert result == {}
+
+
+@patch("src.pipeline.human_intervention.export_versioned_results")
+@patch("src.pipeline.human_intervention.setup_label_studio")
+@patch("src.pipeline.human_intervention._ensure_label_studio_running")
+@patch("src.pipeline.human_intervention._ensure_directories")
+@patch("src.pipeline.human_intervention._initialize_json_files")
+@patch("src.pipeline.human_intervention._generate_ls_tasks")
+@patch("src.pipeline.human_intervention.import_tasks_to_project")
+@patch("builtins.input")
+@patch("pathlib.Path.glob")
+def test_run_human_review_with_export(
+    mock_glob, mock_input, mock_import, mock_generate, mock_initialize, 
+    mock_ensure_dirs, mock_ensure_running, mock_setup, mock_export
+):
+    """Test running workflow with export enabled."""
+    # Setup mocks
+    mock_ensure_running.return_value = True
+    mock_setup.return_value = {
+        "project_id": 123,
+        "storage_id": None,
+        "project_url": "http://localhost:8080/projects/123/data"
+    }
+    mock_generate.return_value = (None, [])
+    mock_export.return_value = [{"id": 1, "data": {}}]
+    mock_input.return_value = ""
+    mock_glob.return_value = []
+
+    with patch.dict("os.environ", {"LABEL_STUDIO_API_KEY": "test_key"}):
+        result = run_human_review("Test Project", export_results_flag=True)
+
+    assert isinstance(result, list)
+    mock_export.assert_called_once()

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -1,0 +1,148 @@
+"""
+Tests for the quantization module.
+"""
+import pytest
+from pathlib import Path
+from unittest.mock import patch, Mock
+
+from src.pipeline.quantization import (
+    imx_quantization,
+    fp16_quantization,
+    onnx_quantization,
+    quantize_model
+)
+
+
+@pytest.fixture
+def mock_model():
+    """Mock YOLO model for testing."""
+    model = Mock()
+    model.export.return_value = "/path/to/exported/model"
+    model.save = Mock()
+    model.half.return_value = model
+    model.model = Mock()
+    model.model.half.return_value = Mock()
+    return model
+
+
+@pytest.fixture
+def sample_quantize_config(tmp_path):
+    """Sample quantization configuration."""
+    return {
+        "output_dir": str(tmp_path / "quantized"),
+        "quantization_method": "IMX",
+        "labeled_images_path": str(tmp_path / "images"),
+        "calibration_samples": 100,
+        "quantize_yaml_path": str(tmp_path / "quantize.yaml")
+    }
+
+
+def test_imx_quantization_non_linux():
+    """Test IMX quantization on non-Linux platforms."""
+    with patch('platform.system', return_value='Windows'):
+        result = imx_quantization(Mock(), "/output/path", "quantize.yaml")
+        assert result is None
+
+
+@patch('platform.system', return_value='Linux')
+@patch('torch.cuda.is_available', return_value=True)
+def test_imx_quantization_success(mock_cuda, mock_platform, mock_model, tmp_path):
+    """Test successful IMX quantization on Linux."""
+    output_path = tmp_path / "quantized_model"
+    exported_path = tmp_path / "exported_model"
+
+    # Create the exported file
+    exported_path.touch()
+    mock_model.export.return_value = str(exported_path)
+
+    with patch('shutil.move') as mock_move:
+        result = imx_quantization(mock_model, str(output_path), "quantize.yaml")
+
+        mock_model.export.assert_called_once_with(format="imx", data="quantize.yaml", device=0)
+        mock_move.assert_called_once()
+        assert result == str(output_path)
+
+
+def test_fp16_quantization_success(mock_model, tmp_path):
+    """Test successful FP16 quantization."""
+    output_path = tmp_path / "fp16_model.pt"
+    result = fp16_quantization(mock_model, str(output_path))
+
+    mock_model.save.assert_called_once_with(str(output_path))
+    assert result == str(output_path)
+
+
+def test_fp16_quantization_failure(mock_model, tmp_path):
+    """Test FP16 quantization failure."""
+    output_path = tmp_path / "fp16_model.pt"
+    mock_model.save.side_effect = Exception("Save failed")
+
+    result = fp16_quantization(mock_model, str(output_path))
+    assert result is None
+
+
+@patch('subprocess.run')
+@patch('src.pipeline.quantization.quantize_dynamic')
+def test_onnx_quantization_success(mock_quantize, mock_subprocess, mock_model, tmp_path):
+    """Test successful ONNX quantization."""
+    output_path = tmp_path / "quantized.onnx"
+    preprocessed_path = tmp_path / "preprocessed.onnx"
+    onnx_path = tmp_path / "model.onnx"
+    mock_model.export.return_value = str(onnx_path)
+    onnx_path.touch()
+    result = onnx_quantization(mock_model, str(output_path), str(preprocessed_path))
+
+    mock_model.export.assert_called_once_with(format='onnx')
+    mock_subprocess.assert_called_once()
+    mock_quantize.assert_called_once()
+    assert result == str(output_path)
+
+
+@patch('src.pipeline.quantization.load_config')
+@patch('src.pipeline.quantization.YOLO')
+@patch('src.pipeline.quantization.prepare_quantization_data')
+def test_quantize_model_imx(mock_prepare, mock_yolo, mock_load_config, sample_quantize_config, tmp_path):
+    """Test quantize_model with IMX method."""
+    mock_load_config.return_value = sample_quantize_config
+    mock_model = Mock()
+    mock_yolo.return_value = mock_model
+
+    # Create quantize.yaml file
+    yaml_path = Path(sample_quantize_config["quantize_yaml_path"])
+    yaml_path.parent.mkdir(parents=True, exist_ok=True)
+    yaml_path.touch()
+
+    with patch('src.pipeline.quantization.imx_quantization') as mock_imx:
+        mock_imx.return_value = "quantized_model_path"
+
+        result = quantize_model("model.pt", "config.json")
+
+        mock_prepare.assert_called_once()
+        mock_imx.assert_called_once()
+        assert result == "quantized_model_path"
+
+
+def test_quantize_model_unsupported_method(tmp_path):
+    """Test quantize_model with unsupported method."""
+    config = {"quantization_method": "UNSUPPORTED", "output_dir": str(tmp_path)}
+
+    with patch('src.pipeline.quantization.load_config', return_value=config):
+        with patch('src.pipeline.quantization.YOLO'):
+            with pytest.raises(ValueError, match="Unsupported quantization method"):
+                quantize_model("model.pt", "config.json")
+
+
+def test_quantize_model_missing_yaml():
+    """Test quantize_model when quantize.yaml is missing."""
+    config = {
+        "quantization_method": "IMX",
+        "output_dir": "/tmp",
+        "labeled_images_path": "/tmp/images",
+        "quantize_yaml_path": "/nonexistent/quantize.yaml"
+    }
+
+    with patch('src.pipeline.quantization.load_config', return_value=config):
+        with patch('src.pipeline.quantization.YOLO'):
+            with patch('src.pipeline.quantization.prepare_quantization_data'):
+                with pytest.raises(ValueError, match="quantize_yaml file does not exist"):
+                    quantize_model("model.pt", "config.json")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,116 @@
+"""
+Tests for utility functions.
+"""
+import os
+import pytest
+import json
+from unittest.mock import patch
+from unittest.mock import mock_open
+from src.utils import (
+    detect_device,
+    load_config,
+    create_data_yaml,
+    create_quantize_yaml
+)
+
+
+@patch('torch.cuda.is_available', return_value=True)
+def test_detect_device_cuda(mock_cuda):
+    assert detect_device() == "cuda"
+
+
+@patch('torch.cuda.is_available', return_value=False)  
+@patch('torch.backends.mps.is_available', return_value=True)
+def test_detect_device_mps(mock_mps, mock_cuda):
+    assert detect_device() == "mps"
+
+
+@patch('torch.cuda.is_available', return_value=False)
+@patch('torch.backends.mps.is_available', return_value=False)
+def test_detect_device_cpu(mock_mps, mock_cuda):
+    assert detect_device() == "cpu"
+
+
+# Config loading tests
+def test_load_config_valid_file(tmp_path):
+    """Test loading a valid config file."""
+    config_file = tmp_path / "config.json"
+    test_config = {"key": "value", "distillation_image_prop": 0.5}
+
+    with open(config_file, 'w') as f:
+        json.dump(test_config, f)
+
+    result = load_config(config_file)
+    assert result == test_config
+
+
+def test_load_config_file_not_found(tmp_path):
+    """Test handling of missing config file."""
+    with pytest.raises(FileNotFoundError):
+        load_config(tmp_path / "nonexistent.json")
+
+
+def test_load_config_invalid_json(tmp_path):
+    """Test handling of invalid JSON."""
+    config_file = tmp_path / "config.json"
+    config_file.write_text("invalid json content")
+
+    with pytest.raises(json.JSONDecodeError):
+        load_config(config_file)
+
+
+def test_load_config_invalid_distillation_prop(tmp_path):
+    """Test validation of distillation_image_prop."""
+    config_file = tmp_path / "config.json"
+    test_config = {"distillation_image_prop": -0.5}
+
+    with open(config_file, 'w') as f:
+        json.dump(test_config, f)
+
+    with pytest.raises(ValueError, match="cannot be negative"):
+        load_config(config_file)
+
+
+def test_load_config_default_path():
+    """Test loading config from default path."""
+    with patch('pathlib.Path.exists', return_value=True):
+        with patch('builtins.open', mock_open(read_data='{"key": "value"}')):
+            result = load_config()
+            assert result == {"key": "value"}
+
+
+def test_create_data_yaml(tmp_path):
+    """Test creating data.yaml file."""
+    create_data_yaml(str(tmp_path))
+
+    # Check if the data.yaml file was created
+    yaml_file = tmp_path / "data.yaml"
+    assert yaml_file.exists()
+
+    # Verify basic content
+    content = yaml_file.read_text()
+    assert "train:" in content
+    assert "val:" in content
+    assert "nc:" in content
+
+
+def test_create_quantize_yaml(tmp_path):
+    """Test creating quantize.yaml file."""
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        create_quantize_yaml(str(tmp_path))
+
+        # Check if the quantize.yaml file was created
+        yaml_file = tmp_path / "src" / "quantize.yaml"
+        assert yaml_file.exists()
+
+        # Verify basic content
+        content = yaml_file.read_text()
+        assert "nc:" in content
+        assert "names:" in content
+    finally:
+        os.chdir(original_cwd)


### PR DESCRIPTION
## Updates

- Added a `process_options` configuration section in `pipeline_config.json` that allows users to skip any pipeline steps:

  ```
  "process_options": {
    "skip_human_review": false,
    "skip_training": false, 
    "skip_distillation": false,
    "skip_quantization": false
  }
  ```
  > Augmentation skipping not implemented since training depends on augmented data

- Model path tracking: Used separate variables (`trained_model_path`, `distilled_model_path`, `quantized_model_path`) that remain None when processes are skipped

  ```
    # Model paths
    base_model_path = model_registry_dir / "model" / "nano_trained_model.pt"
    trained_model_path = None
    distilled_model_path = None
    quantized_model_path = None
  ```

- Clean up pipeline imports with `pipeline/__init__.py`

## Remaining To-Dos

- [ ] Clean up each script
- [ ] Complete `save_model.py`
- [ ]  Clean up the whole repo (final product requirement)