### PR TITLE
Add cleanup script to archive labeled data and clean workspace

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   capstone:
-    image: celt313/automl_capstone:v0.0.2
+    image: celt313/automl_capstone:v0.0.3
     ipc: host
     container_name: automl_capstone
     working_dir: /app
@@ -20,7 +20,7 @@ services:
               capabilities: [gpu]
 
   generate_box:
-    image: celt313/automl_capstone:v0.0.2
+    image: celt313/automl_capstone:v0.0.3
     profiles: ["optional"]
     entrypoint: bash
     command: -c "source activate capstone_env && python src/generate_boxed_images.py"
@@ -28,7 +28,7 @@ services:
       - .:/app
 
   human_intervention:
-    image: celt313/automl_capstone:v0.0.2
+    image: celt313/automl_capstone:v0.0.3
     profiles: ["optional"]
     entrypoint: bash
     command: -c "source activate capstone_env && python src/pipeline/human_intervention.py"
@@ -36,7 +36,7 @@ services:
       - .:/app
 
   test:
-    image: celt313/automl_capstone:v0.0.2
+    image: celt313/automl_capstone:v0.0.3
     profiles: ["optional"]
     entrypoint: bash
     command: -c "source activate capstone_env && pytest tests/"

--- a/environment.yml
+++ b/environment.yml
@@ -37,4 +37,4 @@ dependencies:
       - onnxslim==0.1.53
       - label-studio==1.17.0
       - label-studio-sdk==1.0.11
-      - albumentations==1.4.3
+      - albumentations==2.0.8

--- a/fetch_dataset.sh
+++ b/fetch_dataset.sh
@@ -29,7 +29,7 @@ DATA_ASSET_ID=262360637
 MODEL_ASSET_ID=259250340
 
 # Dataset
-if [ ! -d "$IMAGE_DIR" ]; then
+if [ ! -d "$IMAGE_DIR" ] || [ -z "$(ls -A "$IMAGE_DIR")" ]; then
     echo "📥 Downloading dataset..."
     mkdir -p "automl_workspace/data_pipeline/input"
     curl -L \
@@ -44,7 +44,7 @@ else
 fi
 
 # Model
-if [ ! -d "$MODEL_DIR" ]; then
+if [ ! -d "$MODEL_DIR" ] || [ -z "$(ls -A "$MODEL_DIR")" ]; then
     echo "📥 Downloading model weights..."
     mkdir -p "$MODEL_DIR"
     curl -L \
@@ -64,7 +64,7 @@ DISTILLATION_DIR="automl_workspace/data_pipeline/distillation/distillation_datas
 ZIP_DISTILLATION="automl_workspace/data_pipeline/distillation/distillation_dataset.zip"
 DISTILLATION_ASSET_ID=262351896
 
-if [ ! -d "$DISTILLATION_DIR" ]; then
+if [ ! -d "$DISTILLATION_DIR" ] || [ -z "$(ls -A "$DISTILLATION_DIR")" ]; then
     echo "📥 Downloading distillation dataset..."
     mkdir -p "automl_workspace/data_pipeline/distillation/"
     curl -L \

--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,8 @@ from pipeline import (
     train_model,
     start_distillation,
     quantize_model,
-    register_models
+    register_models,
+    clean_pipeline_workspace
 )
 from directory_setup import create_automl_workspace
 from utils import load_config, prepare_training_data, detect_device
@@ -278,6 +279,11 @@ def main():
         distilled_model=distilled_model_path,
         quantized_model=quantized_model_path
     )
+
+    print("-----------------------------------------------\n")
+    print(" --- Step 11: Final Cleanup and Archival --- ")
+    clean_pipeline_workspace(data_pipeline_dir, master_dataset_dir)
+
 
 
 if __name__ == "__main__":

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -8,6 +8,7 @@ from .train import train_model
 from .distillation.distillation import start_distillation
 from .quantization import quantize_model
 from .save_model import register_models
+from .clean_pipeline import clean_pipeline_workspace
 
 __all__ = [
     'validate_input_images',
@@ -19,5 +20,6 @@ __all__ = [
     'train_model',
     'start_distillation',
     'quantize_model',
-    'register_models'
+    'register_models',
+    'clean_pipeline_workspace'
 ]

--- a/src/pipeline/clean_pipeline.py
+++ b/src/pipeline/clean_pipeline.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+from datetime import datetime
+import shutil
+
+def clean_pipeline_workspace(data_pipeline_dir: Path, master_dataset_dir: Path):
+    """
+    Archives labeled results and cleans the workspace except for label_studio.
+
+    - Copies JSON label files from data_pipeline/labeled to a timestamped folder in master_dataset.
+    - Copies matching images from data_pipeline/input (regardless of extension).
+    - Cleans all folders in data_pipeline except 'label_studio'.
+    """
+
+    labeled_path = data_pipeline_dir / "labeled"
+    input_path = data_pipeline_dir / "input"
+    preserve_folders = {"label_studio"}
+
+    # Step 1: Archive labeled results
+    if labeled_path.exists():
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        archive_dir = master_dataset_dir / f"labeled_{timestamp}"
+        labels_dir = archive_dir / "labels"
+        images_dir = archive_dir / "images"
+        labels_dir.mkdir(parents=True, exist_ok=True)
+        images_dir.mkdir(parents=True, exist_ok=True)
+
+        for json_file in labeled_path.glob("*.json"):
+            # Copy label file
+            shutil.copy(json_file, labels_dir / json_file.name)
+
+            # Match image file by stem (remove `.json`) and look for any extension in input/
+            image_stem = json_file.stem  # keep full stem
+            matching_images = list(input_path.glob(f"{image_stem}.*"))
+
+            if matching_images:
+                shutil.copy(matching_images[0], images_dir / matching_images[0].name)
+            else:
+                print(f"[⚠] Image not found for label {json_file.name}: expected something like {image_stem}.*")
+
+        print(f"[✓] Archived labeled data to {archive_dir}")
+        print(f"[✓] Total archived: {len(list(labels_dir.glob('*.json')))} labels")
+
+    else:
+        print("[Info] No labeled folder found to archive.")
+
+    # Step 2: Clean contents of all folders in data_pipeline except preserved ones
+    for folder in data_pipeline_dir.iterdir():
+        if folder.is_dir() and folder.name not in preserve_folders:
+            for item in folder.iterdir():
+                if item.is_file():
+                    item.unlink()
+                elif item.is_dir():
+                    shutil.rmtree(item)
+

--- a/tests/test_clean_pipeline.py
+++ b/tests/test_clean_pipeline.py
@@ -1,0 +1,62 @@
+"""
+Test suite for `clean_pipeline.py`.
+
+Covers:
+- Archiving of JSON labels and matching images
+- Cleaning all folders except 'label_studio'
+- Preserving empty folder structure after cleaning
+"""
+
+import pytest
+from src.pipeline.clean_pipeline import clean_pipeline_workspace
+
+
+@pytest.fixture
+def setup_clean_test_dirs(tmp_path):
+    """
+    Creates a mock workspace with labeled JSON and matching image in input.
+    """
+    data_pipeline = tmp_path / "data_pipeline"
+    master_dataset = tmp_path / "master_dataset"
+    label_studio = data_pipeline / "label_studio"
+    labeled = data_pipeline / "labeled"
+    input_dir = data_pipeline / "input"
+
+    # Create directories
+    for d in [label_studio, labeled, input_dir, master_dataset]:
+        d.mkdir(parents=True, exist_ok=True)
+
+    # Create matching label and image
+    label_name = "sample_image.json"
+    image_name = "sample_image.png"
+
+    (labeled / label_name).write_text("{}")
+    (input_dir / image_name).write_text("img")
+
+    return data_pipeline, master_dataset, label_name, image_name
+
+
+def test_clean_pipeline_creates_archive_and_cleans(setup_clean_test_dirs):
+    data_pipeline_dir, master_dataset_dir, label_name, image_name = setup_clean_test_dirs
+
+    clean_pipeline_workspace(data_pipeline_dir, master_dataset_dir)
+
+    # Ensure archive folder is created
+    archives = list(master_dataset_dir.glob("labeled_*"))
+    assert len(archives) == 1
+
+    labels_folder = archives[0] / "labels"
+    images_folder = archives[0] / "images"
+
+    # Ensure label and image are copied
+    assert (labels_folder / label_name).exists()
+    assert any(images_folder.glob("sample_image.*"))
+
+    # Ensure only label_studio remains with contents, others are empty
+    for folder in data_pipeline_dir.iterdir():
+        if folder.name == "label_studio":
+            assert folder.exists()
+        else:
+            # Folder exists but is empty
+            assert folder.is_dir()
+            assert not any(folder.iterdir())


### PR DESCRIPTION
- Implemented `clean_pipeline.py` to automatically archive the contents of `data_pipeline/labeled/` into a timestamped folder under `master_dataset/`.
  - Each archive includes two subfolders: `labels/` (for .json files) and `images/` (matched from `data_pipeline/input/` by stem).
- The cleanup step removes the contents of all subfolders in `data_pipeline/` **except** `label_studio/`, which is preserved to retain human review tasks.
- Updated `main.py` to invoke the cleanup script after model registration.
- Added `test_clean_pipeline.py` to verify labeled data archiving, correct image-label matching, and workspace folder cleanup.
